### PR TITLE
Documenting Cisco and Juniper use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ Following is the complete documentation of the field inheritance pattern. Models
 | import_policy | PeerGroupTemplate |
 | role | PeerGroupTemplate |
 
+## Use Cases
+
+To make the start with the plugin easier, we provide two example use cases for common OS platforms: Cisco and Juniper.
+
+### Cisco Configuration Modeling and Rendering
+
+Navigate to [Cisco Example Use Case](docs/cisco_use_case.md) for detailed instructions how to consume BGP Models plugin on Cisco devices.
+
+### Juniper Configuration Modeling and Rendering
+
+Navigate to [Juniper Example Use Case](docs/juniper_use_case.md) for detailed instructions how to consume BGP Models plugin on Juniper devices.
+
 ## Installation
 
 The plugin is available as a Python package in PyPI and can be installed with `pip`:

--- a/docs/cisco_use_case.md
+++ b/docs/cisco_use_case.md
@@ -1,0 +1,391 @@
+# Example use of BGP Models plugin - Cisco BGP Configuration
+This document provides an example of generating a Cisco device's desired BGP configuration based on data stored in Nautobot using this plugin. A GraphQL query is used to retrieve the relevant data, which is then rendered through a Jinja2 template to produce the desired configuration.
+
+## Querying for the data
+In order to retrieve a BGP data, following GraphQL can be issued to a Nautobot.  
+
+```python
+import pynautobot
+import json
+variables = {"device_id": "0a415303-999b-4222-88b8-ba3fef4cdc33"}
+query = """
+query ($device_id: ID!) {
+    device(id: $device_id) {
+        name
+        bgp_routing_instances {
+            extra_attributes
+            autonomous_system {
+                asn
+            }
+            peer_groups {
+                name
+                extra_attributes
+                template {
+                    autonomous_system {
+                        asn
+                    }
+                    import_policy
+                    export_policy
+                    extra_attributes
+                }
+            }
+            endpoints {
+                peer_group {
+                    name
+                }
+                source_ip {
+                    address
+                }
+                peer {
+                    source_ip {
+                        address
+                    }
+                    autonomous_system {
+                        asn
+                    }
+                    routing_instance {
+                        autonomous_system {
+                            asn
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+nb = pynautobot.api(
+    url="http://localhost:8080",
+    token="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+gql = nb.graphql.query(query=query, variables=variables)
+```
+
+## Retrieving the data
+
+An example data returned from Nautobot is presented below.
+
+```json
+{
+  "data": {
+    "device": {
+      "name": "ams01-edge-01",
+      "bgp_routing_instances": [
+        {
+          "extra_attributes": {
+            "auto-summary": false,
+            "synchronization": false
+          },
+          "autonomous_system": {
+            "asn": 65535
+          },
+          "peer_groups": [
+            {
+              "name": "EDGE-to-LEAF",
+              "extra_attributes": null,
+              "template": {
+                "autonomous_system": null,
+                "import_policy": "BGP-LEAF-IN",
+                "export_policy": "BGP-LEAF-OUT",
+                "extra_attributes": {
+                  "next-hop-self": true,
+                  "send-community": true
+                },
+                "role": {
+                  "slug": "peer"
+                }
+              }
+            },
+            {
+              "name": "EDGE-to-TRANSIT",
+              "extra_attributes": null,
+              "template": {
+                "autonomous_system": null,
+                "import_policy": "BGP-TRANSIT-IN",
+                "export_policy": "BGP-TRANSIT-OUT",
+                "extra_attributes": {
+                  "ttl_security_hops": 1
+                },
+                "role": {
+                  "slug": "customer"
+                }
+              }
+            }
+          ],
+          "endpoints": [
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.12/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.13/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.28/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.29/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.8/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.9/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.24/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.25/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.4/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.5/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.20/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.21/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.16/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.17/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.32/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.33/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-TRANSIT"
+              },
+              "source_ip": {
+                "address": "104.94.128.1/29"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "104.94.128.2/29"
+                },
+                "autonomous_system": {
+                  "asn": 1299
+                },
+                "routing_instance": null
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-TRANSIT"
+              },
+              "source_ip": {
+                "address": "104.94.128.9/29"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "104.94.128.10/29"
+                },
+                "autonomous_system": {
+                  "asn": 2914
+                },
+                "routing_instance": null
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Creating Cisco Jinja2 BGP Configuration Template
+
+Following snippet represents an example Cisco BGP Configuration Template:
+
+```
+!
+router bgp {{ data.device.bgp_routing_instances.0.autonomous_system.asn }}
+{%- for peer_group in data.device.bgp_routing_instances.0.peer_groups %}
+ neighbor {{ peer_group.name }} peer-group
+ neighbor {{ peer_group.name }} route-map {{ peer_group.template.import_policy }} in
+ neighbor {{ peer_group.name }} route-map {{ peer_group.template.export_policy }} out
+{%- if "next-hop-self" in peer_group.template.extra_attributes %}
+ neighbor {{ peer_group.name }} next-hop-self
+{%- endif %}
+{%- if "send-community" in peer_group.template.extra_attributes %}
+ neighbor {{ peer_group.name }} send-community
+{%- endif %}
+{%- if "ttl_security_hops" in peer_group.template.extra_attributes %}
+ neighbor {{ peer_group.name }} ttl-security hops {{ peer_group.template.extra_attributes.ttl_security_hops }}
+{%- endif %}
+{%- endfor %}
+!
+{%- for endpoint in data.device.bgp_routing_instances.0.endpoints %}
+{%- if endpoint.peer.autonomous_system %}
+{%- set remote_asn=endpoint.peer.autonomous_system.asn %}
+{%- else %}
+{%- set remote_asn=endpoint.peer.routing_instance.autonomous_system.asn %}
+{%- endif %}
+ neighbor {{ endpoint.peer.source_ip.address | ipaddr('address') }} remote-as {{ remote_asn }}
+{%- if endpoint.peer_group %}
+ neighbor {{ endpoint.peer.source_ip.address | ipaddr('address') }} peer-group {{ endpoint.peer_group.name }}
+{%- endif %}
+{%- endfor %}
+!
+{%- if data.device.bgp_routing_instances.0.extra_attributes.synchronization == false %}
+ no synchronization
+{%- endif %}
+!
+```
+
+
+## Rendering Cisco Jinja2 BGP Configuration Template with the data retrieved from GraphQL
+
+Following snippet represents an example Cisco BGP Renderer Configuration:
+
+```
+! 
+router bgp 65535 
+ neighbor EDGE-to-LEAF peer-group 
+ neighbor EDGE-to-LEAF route-map BGP-LEAF-IN in 
+ neighbor EDGE-to-LEAF route-map BGP-LEAF-OUT out 
+ neighbor EDGE-to-LEAF next-hop-self 
+ neighbor EDGE-to-LEAF send-community 
+ neighbor EDGE-to-TRANSIT peer-group 
+ neighbor EDGE-to-TRANSIT route-map BGP-TRANSIT-IN in 
+ neighbor EDGE-to-TRANSIT route-map BGP-TRANSIT-OUT out 
+ neighbor EDGE-to-TRANSIT ttl-security hops 1 
+! 
+ neighbor 10.11.192.13 remote-as 4200000000 
+ neighbor 10.11.192.13 peer-group EDGE-to-LEAF 
+ neighbor 10.11.192.29 remote-as 4200000000 
+ neighbor 10.11.192.29 peer-group EDGE-to-LEAF 
+ neighbor 10.11.192.9 remote-as 4200000000 
+ neighbor 10.11.192.9 peer-group EDGE-to-LEAF 
+ neighbor 10.11.192.25 remote-as 4200000000 
+ neighbor 10.11.192.25 peer-group EDGE-to-LEAF 
+ neighbor 10.11.192.5 remote-as 4200000000 
+ neighbor 10.11.192.5 peer-group EDGE-to-LEAF 
+ neighbor 10.11.192.21 remote-as 4200000000 
+ neighbor 10.11.192.21 peer-group EDGE-to-LEAF 
+ neighbor 10.11.192.17 remote-as 4200000000 
+ neighbor 10.11.192.17 peer-group EDGE-to-LEAF 
+ neighbor 10.11.192.33 remote-as 4200000000 
+ neighbor 10.11.192.33 peer-group EDGE-to-LEAF 
+ neighbor 104.94.128.2 remote-as 1299 
+ neighbor 104.94.128.2 peer-group EDGE-to-TRANSIT 
+ neighbor 104.94.128.10 remote-as 2914 
+ neighbor 104.94.128.10 peer-group EDGE-to-TRANSIT 
+! 
+ no synchronization 
+!
+```

--- a/docs/juniper_use_case.md
+++ b/docs/juniper_use_case.md
@@ -1,0 +1,397 @@
+# Example use of BGP Models plugin - Juniper BGP Configuration
+This document provides an example of generating a Juniper device's desired BGP configuration based on data stored in Nautobot using this plugin. A GraphQL query is used to retrieve the relevant data, which is then rendered through a Jinja2 template to produce the desired configuration.
+
+## Querying for the data
+In order to retrieve a BGP data, following GraphQL can be issued to a Nautobot.  
+
+```python
+import pynautobot
+import json
+variables = {"device_id": "0a415303-999b-4222-88b8-ba3fef4cdc33"}
+query = """
+query ($device_id: ID!) {
+    device(id: $device_id) {
+        name
+        bgp_routing_instances {
+            extra_attributes
+            autonomous_system {
+                asn
+            }
+            peer_groups {
+                name
+                extra_attributes
+                template {
+                    autonomous_system {
+                        asn
+                    }
+                    import_policy
+                    export_policy
+                    extra_attributes
+                }
+            }
+            endpoints {
+                peer_group {
+                    name
+                }
+                source_ip {
+                    address
+                }
+                peer {
+                    source_ip {
+                        address
+                    }
+                    autonomous_system {
+                        asn
+                    }
+                    routing_instance {
+                        autonomous_system {
+                            asn
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+nb = pynautobot.api(
+    url="http://localhost:8080",
+    token="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+gql = nb.graphql.query(query=query, variables=variables)
+```
+
+## Retrieving the data
+
+An example data returned from Nautobot is presented below.
+
+```json
+{
+  "data": {
+    "device": {
+      "name": "ams01-edge-01",
+      "bgp_routing_instances": [
+        {
+          "extra_attributes": {
+            "auto-summary": false,
+            "synchronization": false
+          },
+          "autonomous_system": {
+            "asn": 65535
+          },
+          "peer_groups": [
+            {
+              "name": "EDGE-to-LEAF",
+              "extra_attributes": null,
+              "template": {
+                "autonomous_system": null,
+                "import_policy": "BGP-LEAF-IN",
+                "export_policy": "BGP-LEAF-OUT",
+                "extra_attributes": {
+                  "next-hop-self": true,
+                  "send-community": true
+                },
+                "role": {
+                  "slug": "peer"
+                }
+              }
+            },
+            {
+              "name": "EDGE-to-TRANSIT",
+              "extra_attributes": null,
+              "template": {
+                "autonomous_system": null,
+                "import_policy": "BGP-TRANSIT-IN",
+                "export_policy": "BGP-TRANSIT-OUT",
+                "extra_attributes": {
+                  "ttl_security_hops": 1
+                },
+                "role": {
+                  "slug": "customer"
+                }
+              }
+            }
+          ],
+          "endpoints": [
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.12/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.13/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.28/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.29/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.8/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.9/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.24/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.25/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.4/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.5/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.20/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.21/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.16/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.17/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-LEAF"
+              },
+              "source_ip": {
+                "address": "10.11.192.32/32"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "10.11.192.33/32"
+                },
+                "autonomous_system": null,
+                "routing_instance": {
+                  "autonomous_system": {
+                    "asn": 4200000000
+                  }
+                }
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-TRANSIT"
+              },
+              "source_ip": {
+                "address": "104.94.128.1/29"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "104.94.128.2/29"
+                },
+                "autonomous_system": {
+                  "asn": 1299
+                },
+                "routing_instance": null
+              }
+            },
+            {
+              "peer_group": {
+                "name": "EDGE-to-TRANSIT"
+              },
+              "source_ip": {
+                "address": "104.94.128.9/29"
+              },
+              "peer": {
+                "source_ip": {
+                  "address": "104.94.128.10/29"
+                },
+                "autonomous_system": {
+                  "asn": 2914
+                },
+                "routing_instance": null
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Creating Juniper Jinja2 BGP Configuration Template
+
+Following snippet represents an example Juniper BGP Configuration Template:
+
+```
+# Set the ASN for Routing Instance
+set routing-options autonomous-system {{ data.device.bgp_routing_instances.0.autonomous_system.asn }}
+
+# Configure Groups 
+{%- for peer_group in data.device.bgp_routing_instances.0.peer_groups %}
+{%- if peer_group.template.role.slug == "peer" %}
+set protocols bgp group {{ peer_group.name }} type internal
+{%- endif %}
+{%- if peer_group.template.role.slug == "customer" %}
+set protocols bgp group {{ peer_group.name }} type external
+{%- endif %}
+set protocols bgp group {{ peer_group.name }} import {{ peer_group.template.import_policy }}
+set protocols bgp group {{ peer_group.name }} export {{ peer_group.template.export_policy }}
+{%- endfor %}
+
+# Configure Peers
+{%- for endpoint in data.device.bgp_routing_instances.0.endpoints %}
+{%- if endpoint.peer.autonomous_system %}
+{%- set remote_asn=endpoint.peer.autonomous_system.asn %}
+{%- else %}
+{%- set remote_asn=endpoint.peer.routing_instance.autonomous_system.asn %}
+{%- endif %}
+set protocols bgp group {{ endpoint.peer_group.name }} neighbor {{ endpoint.peer.source_ip.address | ipaddr('address') }} peer-as {{ remote_asn }}
+{%- endfor %}
+#
+```
+
+
+## Rendering Juniper Jinja2 BGP Configuration Template with the data retrieved from GraphQL
+
+Following snippet represents an example Juniper BGP Renderer Configuration:
+
+```
+root# show protocols bgp
+group EDGE-to-LEAF {
+    type internal;
+    import BGP-LEAF-IN;
+    export BGP-LEAF-OUT;
+    local-as 4200000000;
+    neighbor 10.11.192.13 {
+        peer-as 4200000000;
+    }
+    neighbor 10.11.192.29 {
+        peer-as 4200000000;
+    }
+    neighbor 10.11.192.9 {
+        peer-as 4200000000;
+    }
+    neighbor 10.11.192.25 {
+        peer-as 4200000000;
+    }
+    neighbor 10.11.192.5 {
+        peer-as 4200000000;
+    }
+    neighbor 10.11.192.21 {
+        peer-as 4200000000;
+    }
+    neighbor 10.11.192.17 {
+        peer-as 4200000000;
+    }
+    neighbor 10.11.192.33 {
+        peer-as 4200000000;
+    }
+}
+group EDGE-to-TRANSIT {
+    type external;
+    import BGP-TRANSIT-IN;
+    export BGP-TRANSIT-OUT;
+    neighbor 104.94.128.2 {
+        peer-as 1299;
+    }
+    neighbor 104.94.128.10 {
+        peer-as 2914;
+    }
+}
+
+[edit]
+
+root# show routing-options
+autonomous-system 65535;
+
+[edit]
+```


### PR DESCRIPTION
This PR documents basic use cases for two common OS platforms:
- Cisco
- Juniper

For each platform, following deliverables are provided as a documentation:
- GraphQL query
- JSON Response of the GraphQL query
- Configuration Template (jinja2 format)
- Rendered configuration for a platform (validated and tested on the actual OS for acceptance)


So far stressing the plugin confirms issue documented on: https://github.com/nautobot/nautobot-plugin-bgp-models/issues/43 and the known inconsistency: data presented via UI, REST and GraphQL should be *consistent* (have only one version).

Thus, if our decision was to enable inheritance in UI, similarly it should by default be enabled for Rest and GraphQL. 