### PR TITLE
adds 'tags' to the fields on PeerGroupTemplateForm

### DIFF
--- a/changes/190.fixed
+++ b/changes/190.fixed
@@ -1,0 +1,1 @@
+Fixed missing tags field in PeerGroupTemplateForm.

--- a/nautobot_bgp_models/forms.py
+++ b/nautobot_bgp_models/forms.py
@@ -262,6 +262,7 @@ class PeerGroupTemplateForm(NautobotModelForm):
             "role",
             "autonomous_system",
             "extra_attributes",
+            "tags",
         )
 
 


### PR DESCRIPTION
- PeerGroupTemplateForm tags fixed by Viewsets migration in 2.0

Solves #190