### PR TITLE
fix: 🐛 missing tags in serializers (Nautobot 2.x)

### DIFF
--- a/development/docker-compose.base.yml
+++ b/development/docker-compose.base.yml
@@ -21,8 +21,10 @@ services:
         condition: "service_started"
       db:
         condition: "service_healthy"
-    <<: *nautobot-build
-    <<: *nautobot-base
+    <<:
+      - *nautobot-build
+      - *nautobot-base
+
   worker:
     entrypoint:
       - "sh"

--- a/nautobot_bgp_models/api/serializers.py
+++ b/nautobot_bgp_models/api/serializers.py
@@ -66,6 +66,7 @@ class PeerGroupTemplateSerializer(NautobotModelSerializer, ExtraAttributesSerial
 
 class PeerGroupSerializer(
     InheritableFieldsSerializerMixin,
+    TaggedModelSerializerMixin,
     NautobotModelSerializer,
     ExtraAttributesSerializerMixin,
 ):
@@ -120,7 +121,11 @@ class PeerEndpointSerializer(
         return result
 
 
-class BGPRoutingInstanceSerializer(NautobotModelSerializer, ExtraAttributesSerializerMixin):
+class BGPRoutingInstanceSerializer(
+    NautobotModelSerializer,
+    TaggedModelSerializerMixin,
+    ExtraAttributesSerializerMixin,
+):
     """REST API serializer for Peering records."""
 
     class Meta:

--- a/nautobot_bgp_models/forms.py
+++ b/nautobot_bgp_models/forms.py
@@ -206,6 +206,8 @@ class PeerGroupForm(NautobotModelForm):
 
     secret = DynamicModelChoiceField(queryset=Secret.objects.all(), required=False)
 
+    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
+
     class Meta:
         model = models.PeerGroup
         fields = (
@@ -221,6 +223,7 @@ class PeerGroupForm(NautobotModelForm):
             "autonomous_system",
             "secret",
             "extra_attributes",
+            "tags",
         )
 
 
@@ -367,6 +370,8 @@ class PeerEndpointForm(NautobotModelForm):
         required=False,
     )
 
+    tags = DynamicModelMultipleChoiceField(queryset=Tag.objects.all(), required=False)
+
     class Meta:
         model = models.PeerEndpoint
         fields = (
@@ -381,6 +386,7 @@ class PeerEndpointForm(NautobotModelForm):
             "peer_group",
             "secret",
             "extra_attributes",
+            "tags",
         )
 
     def save(self, commit=True):

--- a/nautobot_bgp_models/tables.py
+++ b/nautobot_bgp_models/tables.py
@@ -42,7 +42,7 @@ class BGPRoutingInstanceTable(StatusTableMixin, BaseTable):
     device = tables.LinkColumn()
     autonomous_system = tables.LinkColumn()
     router_id = tables.LinkColumn()
-    tags = TagColumn(url_name="plugins:nautobot_bgp_models:BGPRoutingInstance_list")
+    tags = TagColumn(url_name="plugins:nautobot_bgp_models:bgproutinginstance_list")
     actions = ButtonsColumn(model=models.BGPRoutingInstance)
 
     class Meta(BaseTable.Meta):
@@ -73,6 +73,7 @@ class PeerGroupTable(BaseTable):
     secret = tables.LinkColumn()
     source_ip = tables.LinkColumn()
     source_interface = tables.LinkColumn()
+    tags = TagColumn(url_name="plugins:nautobot_bgp_models:peergroup_list")
 
     actions = ButtonsColumn(model=models.PeerGroup)
 
@@ -90,6 +91,7 @@ class PeerGroupTable(BaseTable):
             "source_ip",
             "source_interface",
             "secret",
+            "tags",
         )
         default_columns = (
             "pk",
@@ -151,7 +153,7 @@ class PeerEndpointTable(BaseTable):
     peering = tables.LinkColumn()
     vrf = tables.LinkColumn()
     peer_group = tables.LinkColumn()
-
+    tags = TagColumn(url_name="plugins:nautobot_bgp_models:peerendpoint_list")
     # actions = ButtonsColumn(model=models.PeerEndpoint)
 
     class Meta(BaseTable.Meta):
@@ -169,6 +171,7 @@ class PeerEndpointTable(BaseTable):
             "peering",
             "vrf",
             "peer_group",
+            "tags",
         )
         default_columns = (
             "pk",

--- a/nautobot_bgp_models/tests/test_api.py
+++ b/nautobot_bgp_models/tests/test_api.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from nautobot.circuits.models import Provider
 from nautobot.dcim.choices import InterfaceTypeChoices
 from nautobot.dcim.models import Device, DeviceType, Interface, Manufacturer, Location, LocationType
-from nautobot.extras.models import Status, Role
+from nautobot.extras.models import Status, Role, Tag
 from nautobot.ipam.models import IPAddress, VRF, Prefix, Namespace
 from nautobot.apps.testing import APIViewTestCases
 from nautobot.users.models import ObjectPermission
@@ -169,6 +169,8 @@ class BGPRoutingInstanceAPITestCase(APIViewTestCases.APIViewTestCase):
         status_active = Status.objects.get(name__iexact="active")
         status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
         status_active.content_types.add(ContentType.objects.get_for_model(models.BGPRoutingInstance))
+        tag = Tag.objects.create(name="Gerasimos Tag")
+        tag.content_types.add(ContentType.objects.get_for_model(models.BGPRoutingInstance))
 
         manufacturer = Manufacturer.objects.create(name="Cisco")
         devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="CSR 1000V")
@@ -226,6 +228,7 @@ class BGPRoutingInstanceAPITestCase(APIViewTestCases.APIViewTestCase):
                 "router_id": address.pk,
                 "extra_attributes": {"key1": 1, "key2": {"nested_key2": "nested_value2", "nk2": 2}},
                 "status": status_active.pk,
+                "tags": [tag.pk],
             },
         ]
 


### PR DESCRIPTION
This is Nautobot 2.x specific cherry-pick of #165 

TODO:
- [x] manual verification