### PR TITLE
Change cookiecutter model_class_name

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -14,7 +14,7 @@
         "max_nautobot_version": "2.9999",
         "camel_name": "NautobotBGPModels",
         "project_short_description": "Nautobot BGP Models App",
-        "model_class_name": "None",
+        "model_class_name": "AutonomousSystem",
         "open_source_license": "Apache-2.0",
         "docs_base_url": "https://docs.nautobot.com",
         "docs_app_url": "https://docs.nautobot.com/projects/bgp-models/en/latest",

--- a/changes/225.housekeeping
+++ b/changes/225.housekeeping
@@ -1,0 +1,1 @@
+Change model_class_name in .cookiecutter.json to a valid model.

--- a/changes/225.housekeeping
+++ b/changes/225.housekeeping
@@ -1,1 +1,1 @@
-Change model_class_name in .cookiecutter.json to a valid model.
+Changed model_class_name in .cookiecutter.json to a valid model to help with drift management.


### PR DESCRIPTION
Due to the way that Drift Manager uses the .cookiecutter.json file, we need to change the model_class_name to a valid model in BGP models to help us track drift in files that would be removed if the model_class_name=None.