### PR TITLE
Fix device URL link in BGP Routing Instance detail view

### DIFF
--- a/nautobot_bgp_models/templates/nautobot_bgp_models/bgproutinginstance_retrieve.html
+++ b/nautobot_bgp_models/templates/nautobot_bgp_models/bgproutinginstance_retrieve.html
@@ -9,7 +9,7 @@
                 <table class="table table-hover panel-body attr-table">
                     <tr>
                         <td>Device</td>
-                        <td><a href="{{ object.peer_group.get_absolute_url }}">{{ object.device }}</a></td>
+                        <td><a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a></td>
                     </tr>
                     <tr>
                         <td>Router ID</td>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to BGP Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #245

## What's Changed

updated link to go out to dcim:device