### PR TITLE
Removed unneeded routing instance validation

### DIFF
--- a/docs/dev/models.md
+++ b/docs/dev/models.md
@@ -123,8 +123,10 @@ This model represents the configuration of a single device for a single BGP peer
 
 Note that in the case of an external peering (connection with an ISP or Transit Provider), there is no need to create and model the provider's `Device` object. However, as a minimum `PeerEndpoint` (representing the provider's side of `Peering`) created during `Peering` object creation, will have to store IP Address and ASN.
 
-`PeerEndpoint` model has a mandatory FK to a BGP Routing Instance (`BGPRoutingInstance`) record, an optional foreign-key relationship to a `PeerGroup`, and additional keys including:
+`PeerEndpoint` model has optional FK relationships to a BGP Routing Instance (`BGPRoutingInstance`) record, `PeerGroup`, and `AutonomousSystem`, but one of these must be provided with an ASN and the provided ASN must match accoss these relationships. See [Inheritance between models](#inheritance-between-models) below. Additionally, if BGP Routing Instance (`BGPRoutingInstance`) is provided, the [Local-IP](#peerendpoint-local-ip) must be assigned to an Interface on the related Device. Optional fields include:
 
+- Routing Instance (optional, FK to `BGPRoutingInstance`)
+- Peer Group (optional, FK to `PeerGroup`)
 - ASN (optional, FK to `AutonomousSystem`)
 - Peer (optional, FK to `PeerEndpoint`)
 - Source IP (optional, FK to Nautobot `IPAddress`, mutually-exclusive with Source Interface)
@@ -172,18 +174,16 @@ Some models can inherit attribute values, similar to what BGP supports with Peer
 Example **PeerEndpoint** inheritance details:
 
 - A `PeerEndpoint` inherits `AutonomousSystem` and `extra_attributes` fields from:
-    - `PeerGroup`
-    - `PeerGroupTemplate`
-    - `BGPRoutingInstance`
-
+  - `PeerGroup`
+  - `PeerGroupTemplate`
+  - `BGPRoutingInstance`
 
 - A `PeerEndpoint` inherits `description`, `enabled`, `export_policy`, `import_policy` fields from:
-    - `PeerGroup`
-    - `PeerGroupTemplate`
-
+  - `PeerGroup`
+  - `PeerGroupTemplate`
 
 - A `PeerEndpoint` inherits `source_ip`, `source_interface` fields from:
-    - `PeerGroup`
+  - `PeerGroup`
 
 As an example, a `PeerEndpoint` associated with a `PeerGroup` will automatically inherit the above attributes of the `PeerGroup` that haven't been defined at the `PeerEndpoint` level. If an attribute is defined at both levels, the value defined in the `PeerEndpoint` will be used.
 

--- a/nautobot_bgp_models/models.py
+++ b/nautobot_bgp_models/models.py
@@ -11,7 +11,7 @@ from nautobot.circuits.models import Provider
 from nautobot.core.utils.data import deepmerge
 from nautobot.dcim.fields import ASNField
 from nautobot.extras.models import RoleField, StatusField
-from nautobot.ipam.models import IPAddress, IPAddressToInterface
+from nautobot.ipam.models import IPAddress
 from nautobot.tenancy.models import Tenant
 from netutils.asn import int_to_asdot
 
@@ -574,9 +574,6 @@ class PeerEndpoint(PrimaryModel, InheritanceMixin, BGPExtraAttributesMixin):
                 interfaces__in=self.routing_instance.device.vc_interfaces
             ):
                 raise ValidationError("Peer IP not associated with Routing Instance")
-        # Enforce Routing Instance if local IP belongs to the Device
-        elif not self.routing_instance and IPAddressToInterface.objects.filter(ip_address=local_ip_value).exists():
-            raise ValidationError("Must specify Routing Instance for this IP Address")
 
         # Enforce peer group VRF membership
         if self.peer_group is not None:


### PR DESCRIPTION
## What's Changed
This change removes additional validation on PeerEndpoints that requires a Routing Instance to be assigned when the local_ip is associated with any interface. Removing this allows PeerEndpoints to have IP associations with duplicate IP's, IP's assigned to a VMInterface and 

## To Do

- [✅ ] Explanation of Change(s)
- [ ] Added change log fragment(s)
- [✅ ] Unit, Integration Tests
- [✅ ] Documentation Updates (when adding/changing features)

