### PR TITLE
Release v3.0.0

### DIFF
--- a/changes/+nautobot-app-v2.5.1.housekeeping
+++ b/changes/+nautobot-app-v2.5.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.5.1`.

--- a/changes/+nautobot-app-v2.6.0.housekeeping
+++ b/changes/+nautobot-app-v2.6.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.6.0`.

--- a/changes/+nautobot-app-v2.7.0.housekeeping
+++ b/changes/+nautobot-app-v2.7.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.0`.

--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/268.changed
+++ b/changes/268.changed
@@ -1,1 +1,0 @@
-Changed minimum Nautobot version to 2.4.19.

--- a/changes/268.housekeeping
+++ b/changes/268.housekeeping
@@ -1,1 +1,0 @@
-Migrated views to the UI Component Framework.

--- a/changes/269.housekeeping
+++ b/changes/269.housekeeping
@@ -1,1 +1,0 @@
-Added generate_bgp_test_data management command.

--- a/changes/270.housekeeping
+++ b/changes/270.housekeeping
@@ -1,1 +1,0 @@
-Changed Nautobot imports to use nautobot.apps.

--- a/changes/280.changed
+++ b/changes/280.changed
@@ -1,1 +1,0 @@
-Updated navigation menu icon and weights to match Nautobot standard.

--- a/changes/566.housekeeping
+++ b/changes/566.housekeeping
@@ -1,1 +1,0 @@
-Pinned Django debug toolbar to <6.0.0.

--- a/docs/admin/release_notes/version_3.0.md
+++ b/docs/admin/release_notes/version_3.0.md
@@ -4,10 +4,13 @@ This document describes all new features and changes in the release. The format 
 
 ## Release Overview
 
-This major release marks the compatibility of the Device Lifecycle Management App with Nautobot v3.0.0. Check out the full details of the major changes included in this new major release of Nautobot. Highlights:
+This major release marks the compatibility of the App with Nautobot 3.0.0. Check out the [full details](https://docs.nautobot.com/projects/core/en/stable/release-notes/version-3.0/) of the changes included in this new major release of Nautobot. Highlights:
 
-Added support for Python 3.13.
-The minimum version of Nautobot required for this app is Nautobot 3.0. We will continue to support the previous major release for users of Nautobot LTM 2.4 only with bug and security fixes as per the LTM Policy. (Add note about previous major version compatible with LTM with link to website LTM policy.)
+- Minimum Nautobot version supported is 3.0.
+- Added support for Python 3.13 and removed support for 3.9.
+- Updated UI framework to use latest Bootstrap 5.3.
+
+We will continue to support the previous major release for users of Nautobot LTM 2.4 only with critical bug and security fixes as per the [Software Lifecycle Policy](https://networktocode.com/company/legal/software-lifecycle-policy/).
 
 <!-- towncrier release notes start -->
 

--- a/docs/admin/release_notes/version_3.0.md
+++ b/docs/admin/release_notes/version_3.0.md
@@ -4,19 +4,22 @@ This document describes all new features and changes in the release. The format 
 
 ## Release Overview
 
-- Added support for Nautobot 3.0.
-- Added support for Python 3.13.
+This major release marks the compatibility of the Device Lifecycle Management App with Nautobot v3.0.0. Check out the full details of the major changes included in this new major release of Nautobot. Highlights:
+
+Added support for Python 3.13.
+The minimum version of Nautobot required for this app is Nautobot 3.0. We will continue to support the previous major release for users of Nautobot LTM 2.4 only with bug and security fixes as per the LTM Policy. (Add note about previous major version compatible with LTM with link to website LTM policy.)
 
 <!-- towncrier release notes start -->
 
-
-## [v3.0.0a2 (2025-11-06)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v3.0.0a2)
-
-- [#280](https://github.com/nautobot/nautobot-app-bgp-models/issues/280) - Updated navigation menu icon and weights to match Nautobot standard.
-
-## [v3.0.0a1 (2025-11-03)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v3.0.0a1)
+## [v3.0.0 (2025-11-17)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v3.0.0)
 
 ### Added
 
 - Added support for Python 3.13.
 - Added support for Nautobot 3.0.
+
+### Changed
+
+- [#280](https://github.com/nautobot/nautobot-app-bgp-models/issues/280) - Updated navigation menu icon and weights to match Nautobot standard.
+
+## [v3.0.0a2 (2025-11-06)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v3.0.0a2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-bgp-models"
-version = "3.0.0a3"
+version = "3.0.0"
 description = "Nautobot BGP Models App"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
-nautobot = ">=3.0.0a2,<3.0.0rc99"
+nautobot = ">=3.0.0,<4.0.0"
 netutils = "^1.6.0"
 toml = "^0.10.2"
 


### PR DESCRIPTION
# TODO

- Finalized release notes
- Poetry lock after Nautobot v3 is released

# v3.0 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

This major release marks the compatibility of the App with Nautobot 3.0.0. Check out the [full details](https://docs.nautobot.com/projects/core/en/stable/release-notes/version-3.0/) of the changes included in this new major release of Nautobot. Highlights:

- Minimum Nautobot version supported is 3.0.
- Added support for Python 3.13 and removed support for 3.9.
- Updated UI framework to use latest Bootstrap 5.3.

We will continue to support the previous major release for users of Nautobot LTM 2.4 only with critical bug and security fixes as per the [Software Lifecycle Policy](https://networktocode.com/company/legal/software-lifecycle-policy/).

<!-- towncrier release notes start -->

## [v3.0.0 (2025-11-17)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v3.0.0)

### Added

- Added support for Python 3.13.
- Added support for Nautobot 3.0.

### Changed

- [#280](https://github.com/nautobot/nautobot-app-bgp-models/issues/280) - Updated navigation menu icon and weights to match Nautobot standard.