### PR TITLE
Updated q filtering for device names

### DIFF
--- a/changes/290.changed
+++ b/changes/290.changed
@@ -1,0 +1,1 @@
+Changed device name filtering on PeerEndpoint, AddressFamily, and PeerEndpointAddressFamily to use substring matching instead of exact matching.

--- a/changes/290.changed
+++ b/changes/290.changed
@@ -1,1 +1,1 @@
-Changed device name filtering on PeerEndpoint, AddressFamily, and PeerEndpointAddressFamily to use substring matching instead of exact matching.
+Changed q filtering on PeerEndpoint, AddressFamily, and PeerEndpointAddressFamily to perform substring matching on device names instead of exact matching.

--- a/changes/290.changed
+++ b/changes/290.changed
@@ -1,1 +1,1 @@
-Changed q filtering on PeerEndpoint, AddressFamily, and PeerEndpointAddressFamily to perform substring matching on device names instead of exact matching.
+Changed search filter on PeerEndpoint, AddressFamily, and PeerEndpointAddressFamily to perform "contains" filtering on device names instead of "exact" matching.

--- a/changes/290.housekeeping
+++ b/changes/290.housekeeping
@@ -1,0 +1,1 @@
+Updated tests to reflect the new substring based device name filtering.

--- a/nautobot_bgp_models/filters.py
+++ b/nautobot_bgp_models/filters.py
@@ -169,7 +169,7 @@ class PeerEndpointFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
 
     q = SearchFilter(
         filter_predicates={
-            "routing_instance__device__name": "iexact",
+            "routing_instance__device__name": "icontains",
             "description": "icontains",
         },
     )
@@ -260,7 +260,7 @@ class AddressFamilyFilterSet(BaseFilterSet, CreatedUpdatedModelFilterSetMixin, C
 
     q = SearchFilter(
         filter_predicates={
-            "routing_instance__device__name": "iexact",
+            "routing_instance__device__name": "icontains",
         },
     )
 
@@ -324,7 +324,7 @@ class PeerEndpointAddressFamilyFilterSet(
     q = SearchFilter(
         filter_predicates={
             "afi_safi": "icontains",
-            "peer_endpoint__routing_instance__device__name": "iexact",
+            "peer_endpoint__routing_instance__device__name": "icontains",
             "peer_endpoint__description": "icontains",
         },
     )

--- a/nautobot_bgp_models/tests/test_filters.py
+++ b/nautobot_bgp_models/tests/test_filters.py
@@ -326,8 +326,7 @@ class PeerEndpointTestCase(FilterTestCases.BaseFilterTestCase):
 
     def test_search(self):
         """Test text search."""
-        self.assertEqual(self.filterset({"q": "Device 1"}, self.queryset).qs.count(), 2)
-        self.assertEqual(self.filterset({"q": "dev"}, self.queryset).qs.count(), 0)
+        self.assertEqual(self.filterset({"q": "dev"}, self.queryset).qs.count(), 2)
 
     def test_id(self):
         """Test filtering by ID (primary key)."""
@@ -700,6 +699,9 @@ class AddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
         device1 = Device.objects.create(
             device_type=devicetype, role=devicerole, name="Device 1", location=location, status=status_active
         )
+        device2 = Device.objects.create(
+            device_type=devicetype, role=devicerole, name="Router-8", location=location, status=status_active
+        )
         interface_status = Status.objects.get_for_model(Interface).first()
         interface = Interface.objects.create(device=device1, name="Loopback1", status=interface_status)
 
@@ -716,22 +718,28 @@ class AddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
 
         asn1 = models.AutonomousSystem.objects.create(asn=65000, status=status_active)
 
-        cls.bgp_routing_instance = models.BGPRoutingInstance.objects.create(
+        cls.bgp_routing_instance1 = models.BGPRoutingInstance.objects.create(
             description="Hello World!",
             autonomous_system=asn1,
             device=device1,
             status=status_active,
         )
+        cls.bgp_routing_instance2 = models.BGPRoutingInstance.objects.create(
+            description="Hello World!",
+            autonomous_system=asn1,
+            device=device2,
+            status=status_active,
+        )
 
         cls.peergroup = models.PeerGroup.objects.create(
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=cls.bgp_routing_instance1,
             name="Group B",
             role=peeringrole,
         )
 
         peering = models.Peering.objects.create(status=status_active)
         cls.endpoint = models.PeerEndpoint.objects.create(
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=cls.bgp_routing_instance1,
             source_ip=address,
             peering=peering,
         )
@@ -739,18 +747,18 @@ class AddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
         cls.vrf = VRF.objects.create(name="VRF 1", rd="65000:1", status=status_active)
 
         models.AddressFamily.objects.create(
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=cls.bgp_routing_instance1,
             afi_safi=choices.AFISAFIChoices.AFI_IPV4_UNICAST,
             vrf=cls.vrf,
         )
 
         models.AddressFamily.objects.create(
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=cls.bgp_routing_instance1,
             afi_safi=choices.AFISAFIChoices.AFI_IPV4_FLOWSPEC,
         )
 
         models.AddressFamily.objects.create(
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=cls.bgp_routing_instance2,
             afi_safi=choices.AFISAFIChoices.AFI_VPNV4_UNICAST,
         )
 
@@ -770,7 +778,7 @@ class AddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
 
     def test_search(self):
         """Test filtering by Q search value."""
-        self.assertEqual(self.filterset({"q": "Device 1"}, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset({"q": "dev"}, self.queryset).qs.count(), 2)
 
     def test_vrf(self):
         """Test filtering by VRF."""
@@ -988,7 +996,7 @@ class PeerEndpointAddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
         """Test text search."""
         self.assertEqual(self.filterset({"q": "ipv4_uni"}, self.queryset).qs.count(), 3)
         self.assertEqual(self.filterset({"q": "endpoint"}, self.queryset).qs.count(), 2)
-        self.assertEqual(self.filterset({"q": "Device 1"}, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset({"q": "dev"}, self.queryset).qs.count(), 3)
 
     def test_id(self):
         """Test filtering by ID (primary key)."""


### PR DESCRIPTION
# Closes: #NAPPS-726

## What's Changed

- Changed q filtering on PeerEndpoint, AddressFamily, and PeerEndpointAddressFamily to perform substring matching on device names instead of exact matching.
- Updated tests to reflect the new substring based device name filtering.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

