### PR TITLE
Release v2.4.0

### DIFF
--- a/changes/+nautobot-app-v2.5.1.housekeeping
+++ b/changes/+nautobot-app-v2.5.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.5.1`.

--- a/changes/+nautobot-app-v2.6.0.housekeeping
+++ b/changes/+nautobot-app-v2.6.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.6.0`.

--- a/changes/+nautobot-app-v2.7.0.housekeeping
+++ b/changes/+nautobot-app-v2.7.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.0`.

--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/+nautobot-app-v2.7.2.housekeeping
+++ b/changes/+nautobot-app-v2.7.2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/changes/268.changed
+++ b/changes/268.changed
@@ -1,1 +1,0 @@
-Changed minimum Nautobot version to 2.4.19.

--- a/changes/268.housekeeping
+++ b/changes/268.housekeeping
@@ -1,1 +1,0 @@
-Migrated views to the UI Component Framework.

--- a/changes/269.housekeeping
+++ b/changes/269.housekeeping
@@ -1,1 +1,0 @@
-Added generate_bgp_test_data management command.

--- a/changes/270.housekeeping
+++ b/changes/270.housekeeping
@@ -1,1 +1,0 @@
-Changed Nautobot imports to use nautobot.apps.

--- a/changes/289.fixed
+++ b/changes/289.fixed
@@ -1,1 +1,0 @@
-Fixed minor UI bugs.

--- a/changes/566.housekeeping
+++ b/changes/566.housekeeping
@@ -1,1 +1,0 @@
-Pinned Django debug toolbar to <6.0.0.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -1,0 +1,30 @@
+# v2.4 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Changed minimum Nautobot version to 2.4.20.
+- Dropped support for Python 3.9.
+
+<!-- towncrier release notes start -->
+## [v2.4.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v2.4.0)
+
+### Fixed
+
+- [#289](https://github.com/nautobot/nautobot-app-bgp-models/issues/289) - Fixed minor UI bugs.
+
+### Dependencies
+
+- [#566](https://github.com/nautobot/nautobot-app-bgp-models/issues/566) - Pinned Django debug toolbar to <6.0.0.
+
+### Housekeeping
+
+- [#268](https://github.com/nautobot/nautobot-app-bgp-models/issues/268) - Migrated views to the UI Component Framework.
+- [#269](https://github.com/nautobot/nautobot-app-bgp-models/issues/269) - Added generate_bgp_test_data management command.
+- [#270](https://github.com/nautobot/nautobot-app-bgp-models/issues/270) - Changed Nautobot imports to use nautobot.apps.
+- Rebaked from the cookie `nautobot-app-v2.5.1`.
+- Rebaked from the cookie `nautobot-app-v2.6.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.1`.
+- Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -8,7 +8,7 @@ This document describes all new features and changes in the release. The format 
 - Dropped support for Python 3.9.
 
 <!-- towncrier release notes start -->
-## [v2.4.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v2.4.0)
+## [v2.4.0 (2025-12-12)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v2.4.0)
 
 ### Fixed
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v2.4: "admin/release_notes/version_2.4.md"
           - v0.7: "admin/release_notes/version_0.7.md"
           - v0.8: "admin/release_notes/version_0.8.md"
           - v0.9: "admin/release_notes/version_0.9.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-bgp-models"
-version = "2.4.0a0"
+version = "2.4.0"
 description = "Nautobot BGP Models App"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"
@@ -172,7 +172,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_bgp_models"
 directory = "changes"
-filename = "docs/admin/release_notes/version_2.3.md"
+filename = "docs/admin/release_notes/version_2.4.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-bgp-models/issues/{issue})"


### PR DESCRIPTION
# v2.4 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Changed minimum Nautobot version to 2.4.20.
- Dropped support for Python 3.9.

## [v2.4.0 (2025-12-12)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v2.4.0)

### Fixed

- [#289](https://github.com/nautobot/nautobot-app-bgp-models/issues/289) - Fixed minor UI bugs.

### Dependencies

- [#566](https://github.com/nautobot/nautobot-app-bgp-models/issues/566) - Pinned Django debug toolbar to <6.0.0.

### Housekeeping

- [#268](https://github.com/nautobot/nautobot-app-bgp-models/issues/268) - Migrated views to the UI Component Framework.
- [#269](https://github.com/nautobot/nautobot-app-bgp-models/issues/269) - Added generate_bgp_test_data management command.
- [#270](https://github.com/nautobot/nautobot-app-bgp-models/issues/270) - Changed Nautobot imports to use nautobot.apps.
- Rebaked from the cookie `nautobot-app-v2.5.1`.
- Rebaked from the cookie `nautobot-app-v2.6.0`.
- Rebaked from the cookie `nautobot-app-v2.7.0`.
- Rebaked from the cookie `nautobot-app-v2.7.1`.
- Rebaked from the cookie `nautobot-app-v2.7.2`.
