### PR TITLE
Updating filter tests

### DIFF
--- a/changes/298.added
+++ b/changes/298.added
@@ -1,0 +1,1 @@
+Added missing filter definitions to applicable models.

--- a/changes/298.changed
+++ b/changes/298.changed
@@ -1,0 +1,1 @@
+Replaced device_id filters with device, which now supports filtering by both device name and ID.

--- a/changes/298.changed
+++ b/changes/298.changed
@@ -1,1 +1,0 @@
-Replaced device_id filters with device, which now supports filtering by both device name and ID.

--- a/changes/298.housekeeping
+++ b/changes/298.housekeeping
@@ -1,0 +1,1 @@
+Updated tests to use `FilterTestCase` instead of `BaseFilterTestCase` and `generic_filter_tests` to replace repetitive test cases.

--- a/nautobot_bgp_models/filters.py
+++ b/nautobot_bgp_models/filters.py
@@ -187,6 +187,14 @@ class PeerEndpointFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
         },
     )
 
+    # TODO: Remove this filter. Deprecated in favor of below NaturalKeyOrPKMultipleChoiceFilter `device`
+    device_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="routing_instance__device__id",
+        queryset=Device.objects.all(),
+        to_field_name="id",
+        label="Device (ID)",
+    )
+
     device = NaturalKeyOrPKMultipleChoiceFilter(
         field_name="routing_instance__device",
         queryset=Device.objects.all(),
@@ -222,6 +230,14 @@ class PeeringFilterSet(StatusModelFilterSetMixin, NautobotFilterSet):
         filter_predicates={
             "endpoints__routing_instance__device__name": "icontains",
         },
+    )
+
+    # TODO: Remove this filter. Deprecated in favor of below NaturalKeyOrPKMultipleChoiceFilter `device`
+    device_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="endpoints__routing_instance__device__id",
+        queryset=Device.objects.all(),
+        to_field_name="id",
+        label="Device (ID)",
     )
 
     device = NaturalKeyOrPKMultipleChoiceFilter(
@@ -260,21 +276,6 @@ class AddressFamilyFilterSet(NautobotFilterSet):
     )
 
     afi_safi = django_filters.MultipleChoiceFilter(choices=choices.AFISAFIChoices)
-
-    # TODO: Remove this filter. Deprecated in favor of below NaturalKeyOrPKMultipleChoiceFilter `device`
-    device_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="routing_instance__device__id",
-        queryset=Device.objects.all(),
-        to_field_name="id",
-        label="Device (ID)",
-    )
-
-    device = NaturalKeyOrPKMultipleChoiceFilter(
-        field_name="routing_instance__device",
-        queryset=Device.objects.all(),
-        to_field_name="name",
-        label="Device (name or ID)",
-    )
 
     routing_instance = django_filters.ModelMultipleChoiceFilter(
         field_name="routing_instance__id",

--- a/nautobot_bgp_models/filters.py
+++ b/nautobot_bgp_models/filters.py
@@ -191,7 +191,7 @@ class PeerEndpointFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
         fields = ["id", "enabled", "tags"]
 
 
-class PeeringFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
+class PeeringFilterSet(StatusModelFilterSetMixin, NautobotFilterSet):
     """Filtering of Peering records."""
 
     # TODO(mzb): Add in-memory filtering for Provider, ASN, IP Address, ...

--- a/nautobot_bgp_models/filters.py
+++ b/nautobot_bgp_models/filters.py
@@ -14,6 +14,7 @@ from nautobot.circuits.models import Provider
 from nautobot.dcim.models import Device
 from nautobot.extras.models import Role
 from nautobot.ipam.models import VRF
+from nautobot.tenancy.models import Tenant
 
 from . import choices, models
 
@@ -42,7 +43,7 @@ class AutonomousSystemFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
 
     class Meta:
         model = models.AutonomousSystem
-        fields = ["id", "asn", "status", "tags"]
+        fields = "__all__"
 
     def filter_present_in_asn_range(self, queryset, name, value):  # pylint: disable=unused-argument
         """Filter Autonomous Systems that are present in any of the given ASN Ranges."""
@@ -66,9 +67,15 @@ class AutonomousSystemRangeFilterSet(NautobotFilterSet):
         },
     )
 
+    tenant = NaturalKeyOrPKMultipleChoiceFilter(
+        queryset=Tenant.objects.all(),
+        to_field_name="name",
+        label="Tenant (name or ID)",
+    )
+
     class Meta:
         model = models.AutonomousSystemRange
-        fields = ["id", "name", "asn_min", "asn_max", "tags"]
+        fields = "__all__"
 
 
 class BGPRoutingInstanceFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
@@ -87,15 +94,22 @@ class BGPRoutingInstanceFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
         label="Autonomous System Number",
     )
 
+    # TODO: Remove this filter. Deprecated in favor of below NaturalKeyOrPKMultipleChoiceFilter `device`
+    device_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Device.objects.all(),
+        label="Device (ID)",
+    )
+    
     device = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=Device.objects.all(),
         to_field_name="name",
         label="Device (name or ID)",
     )
 
+
     class Meta:
         model = models.BGPRoutingInstance
-        fields = ["id", "tags"]
+        fields = "__all__"
 
 
 class PeerGroupFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
@@ -122,6 +136,14 @@ class PeerGroupFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
         label="BGP Routing Instance ID",
     )
 
+    # TODO: Remove this filter. Deprecated in favor of below NaturalKeyOrPKMultipleChoiceFilter `device`
+    device_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="routing_instance__device__id",
+        queryset=Device.objects.all(),
+        to_field_name="id",
+        label="Device (ID)",
+    )
+
     device = NaturalKeyOrPKMultipleChoiceFilter(
         field_name="routing_instance__device",
         queryset=Device.objects.all(),
@@ -131,7 +153,7 @@ class PeerGroupFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
 
     class Meta:
         model = models.PeerGroup
-        fields = ["id", "name", "enabled", "tags"]
+        fields = "__all__"
 
 
 class PeerGroupTemplateFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
@@ -153,7 +175,7 @@ class PeerGroupTemplateFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
 
     class Meta:
         model = models.PeerGroupTemplate
-        fields = ["id", "name", "enabled", "tags"]
+        fields = "__all__"
 
 
 class PeerEndpointFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
@@ -188,7 +210,7 @@ class PeerEndpointFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
 
     class Meta:
         model = models.PeerEndpoint
-        fields = ["id", "enabled", "tags"]
+        fields = "__all__"
 
 
 class PeeringFilterSet(StatusModelFilterSetMixin, NautobotFilterSet):
@@ -226,7 +248,7 @@ class PeeringFilterSet(StatusModelFilterSetMixin, NautobotFilterSet):
 
     class Meta:
         model = models.Peering
-        fields = ["id"]
+        fields = "__all__"
 
 
 class AddressFamilyFilterSet(NautobotFilterSet):
@@ -239,6 +261,14 @@ class AddressFamilyFilterSet(NautobotFilterSet):
     )
 
     afi_safi = django_filters.MultipleChoiceFilter(choices=choices.AFISAFIChoices)
+
+    # TODO: Remove this filter. Deprecated in favor of below NaturalKeyOrPKMultipleChoiceFilter `device`
+    device_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="routing_instance__device__id",
+        queryset=Device.objects.all(),
+        to_field_name="id",
+        label="Device (ID)",
+    )
 
     device = NaturalKeyOrPKMultipleChoiceFilter(
         field_name="routing_instance__device",
@@ -262,9 +292,7 @@ class AddressFamilyFilterSet(NautobotFilterSet):
 
     class Meta:
         model = models.AddressFamily
-        fields = [
-            "id",
-        ]
+        fields = "__all__"
 
 
 class PeerGroupAddressFamilyFilterSet(NautobotFilterSet):
@@ -288,9 +316,7 @@ class PeerGroupAddressFamilyFilterSet(NautobotFilterSet):
 
     class Meta:
         model = models.PeerGroupAddressFamily
-        fields = [
-            "id",
-        ]
+        fields = "__all__"
 
 
 class PeerEndpointAddressFamilyFilterSet(NautobotFilterSet):
@@ -313,8 +339,4 @@ class PeerEndpointAddressFamilyFilterSet(NautobotFilterSet):
 
     class Meta:
         model = models.PeerEndpointAddressFamily
-        fields = [
-            "id",
-            "afi_safi",
-            "peer_endpoint",
-        ]
+        fields = "__all__"

--- a/nautobot_bgp_models/filters.py
+++ b/nautobot_bgp_models/filters.py
@@ -4,15 +4,13 @@
 import django_filters
 from django.db.models import Q
 from nautobot.apps.filters import (
-    BaseFilterSet,
-    CreatedUpdatedModelFilterSetMixin,
-    CustomFieldModelFilterSetMixin,
     NaturalKeyOrPKMultipleChoiceFilter,
     NautobotFilterSet,
     RoleModelFilterSetMixin,
     SearchFilter,
     StatusModelFilterSetMixin,
 )
+from nautobot.circuits.models import Provider
 from nautobot.dcim.models import Device
 from nautobot.extras.models import Role
 from nautobot.ipam.models import VRF
@@ -29,6 +27,13 @@ class AutonomousSystemFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
             "description": "icontains",
         },
     )
+
+    provider = NaturalKeyOrPKMultipleChoiceFilter(
+        queryset=Provider.objects.all(),
+        label="Provider (name or ID)",
+        to_field_name="name",
+    )
+
     autonomous_system_range = django_filters.ModelMultipleChoiceFilter(
         queryset=models.AutonomousSystemRange.objects.all(),
         label="ASN Range",
@@ -37,7 +42,7 @@ class AutonomousSystemFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
 
     class Meta:
         model = models.AutonomousSystem
-        fields = ["id", "asn", "status", "tags", "autonomous_system_range"]
+        fields = ["id", "asn", "status", "tags"]
 
     def filter_present_in_asn_range(self, queryset, name, value):  # pylint: disable=unused-argument
         """Filter Autonomous Systems that are present in any of the given ASN Ranges."""
@@ -82,21 +87,15 @@ class BGPRoutingInstanceFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
         label="Autonomous System Number",
     )
 
-    device_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Device.objects.all(),
-        label="Device (ID)",
-    )
-
-    device = django_filters.ModelMultipleChoiceFilter(
-        field_name="device__name",
+    device = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=Device.objects.all(),
         to_field_name="name",
-        label="Device (name)",
+        label="Device (name or ID)",
     )
 
     class Meta:
         model = models.BGPRoutingInstance
-        fields = ["id", "autonomous_system", "tags"]
+        fields = ["id", "tags"]
 
 
 class PeerGroupFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
@@ -123,23 +122,16 @@ class PeerGroupFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
         label="BGP Routing Instance ID",
     )
 
-    device = django_filters.ModelMultipleChoiceFilter(
-        field_name="routing_instance__device__name",
+    device = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="routing_instance__device",
         queryset=Device.objects.all(),
         to_field_name="name",
-        label="Device (name)",
-    )
-
-    device_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="routing_instance__device__id",
-        queryset=Device.objects.all(),
-        to_field_name="id",
-        label="Device (ID)",
+        label="Device (name or ID)",
     )
 
     class Meta:
         model = models.PeerGroup
-        fields = ["id", "name", "enabled"]
+        fields = ["id", "name", "enabled", "tags"]
 
 
 class PeerGroupTemplateFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
@@ -161,7 +153,7 @@ class PeerGroupTemplateFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
 
     class Meta:
         model = models.PeerGroupTemplate
-        fields = ["id", "name", "enabled"]
+        fields = ["id", "name", "enabled", "tags"]
 
 
 class PeerEndpointFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
@@ -174,18 +166,11 @@ class PeerEndpointFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
         },
     )
 
-    device = django_filters.ModelMultipleChoiceFilter(
-        field_name="routing_instance__device__name",
+    device = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="routing_instance__device",
         queryset=Device.objects.all(),
         to_field_name="name",
-        label="Device (name)",
-    )
-
-    device_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="routing_instance__device__id",
-        queryset=Device.objects.all(),
-        to_field_name="id",
-        label="Device (ID)",
+        label="Device (name or ID)",
     )
 
     autonomous_system = django_filters.ModelMultipleChoiceFilter(
@@ -195,22 +180,18 @@ class PeerEndpointFilterSet(NautobotFilterSet, RoleModelFilterSetMixin):
         label="Autonomous System Number",
     )
 
-    peer_group = django_filters.ModelMultipleChoiceFilter(
+    peer_group = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=models.PeerGroup.objects.all(),
-        label="Peer Group (id)",
+        to_field_name="name",
+        label="Peer Group (name or ID)",
     )
 
     class Meta:
         model = models.PeerEndpoint
-        fields = ["id", "enabled"]
+        fields = ["id", "enabled", "tags"]
 
 
-class PeeringFilterSet(
-    BaseFilterSet,
-    CreatedUpdatedModelFilterSetMixin,
-    CustomFieldModelFilterSetMixin,
-    StatusModelFilterSetMixin,
-):
+class PeeringFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
     """Filtering of Peering records."""
 
     # TODO(mzb): Add in-memory filtering for Provider, ASN, IP Address, ...
@@ -222,18 +203,11 @@ class PeeringFilterSet(
         },
     )
 
-    device = django_filters.ModelMultipleChoiceFilter(
-        field_name="endpoints__routing_instance__device__name",
+    device = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="endpoints__routing_instance__device",
         queryset=Device.objects.all(),
         to_field_name="name",
-        label="Device (name)",
-    )
-
-    device_id = django_filters.ModelMultipleChoiceFilter(
-        field_name="endpoints__routing_instance__device__id",
-        queryset=Device.objects.all(),
-        to_field_name="id",
-        label="Device (ID)",
+        label="Device (name or ID)",
     )
 
     device_role = django_filters.ModelMultipleChoiceFilter(
@@ -255,7 +229,7 @@ class PeeringFilterSet(
         fields = ["id"]
 
 
-class AddressFamilyFilterSet(BaseFilterSet, CreatedUpdatedModelFilterSetMixin, CustomFieldModelFilterSetMixin):
+class AddressFamilyFilterSet(NautobotFilterSet):
     """Filtering of AddressFamily records."""
 
     q = SearchFilter(
@@ -265,6 +239,13 @@ class AddressFamilyFilterSet(BaseFilterSet, CreatedUpdatedModelFilterSetMixin, C
     )
 
     afi_safi = django_filters.MultipleChoiceFilter(choices=choices.AFISAFIChoices)
+
+    device = NaturalKeyOrPKMultipleChoiceFilter(
+        field_name="routing_instance__device",
+        queryset=Device.objects.all(),
+        to_field_name="name",
+        label="Device (name or ID)",
+    )
 
     routing_instance = django_filters.ModelMultipleChoiceFilter(
         field_name="routing_instance__id",
@@ -283,13 +264,10 @@ class AddressFamilyFilterSet(BaseFilterSet, CreatedUpdatedModelFilterSetMixin, C
         model = models.AddressFamily
         fields = [
             "id",
-            "routing_instance",
-            "afi_safi",
-            "vrf",
         ]
 
 
-class PeerGroupAddressFamilyFilterSet(BaseFilterSet, CreatedUpdatedModelFilterSetMixin, CustomFieldModelFilterSetMixin):
+class PeerGroupAddressFamilyFilterSet(NautobotFilterSet):
     """Filtering of PeerGroupAddressFamily records."""
 
     q = SearchFilter(
@@ -302,23 +280,20 @@ class PeerGroupAddressFamilyFilterSet(BaseFilterSet, CreatedUpdatedModelFilterSe
 
     afi_safi = django_filters.MultipleChoiceFilter(choices=choices.AFISAFIChoices)
 
-    peer_group = django_filters.ModelMultipleChoiceFilter(
-        label="Peer Group (ID)",
+    peer_group = NaturalKeyOrPKMultipleChoiceFilter(
+        label="Peer Group (name or ID)",
         queryset=models.PeerGroup.objects.all(),
+        to_field_name="name",
     )
 
     class Meta:
         model = models.PeerGroupAddressFamily
         fields = [
             "id",
-            "afi_safi",
-            "peer_group",
         ]
 
 
-class PeerEndpointAddressFamilyFilterSet(
-    BaseFilterSet, CreatedUpdatedModelFilterSetMixin, CustomFieldModelFilterSetMixin
-):
+class PeerEndpointAddressFamilyFilterSet(NautobotFilterSet):
     """Filtering of PeerEndpointAddressFamily records."""
 
     q = SearchFilter(

--- a/nautobot_bgp_models/filters.py
+++ b/nautobot_bgp_models/filters.py
@@ -99,13 +99,12 @@ class BGPRoutingInstanceFilterSet(NautobotFilterSet, StatusModelFilterSetMixin):
         queryset=Device.objects.all(),
         label="Device (ID)",
     )
-    
+
     device = NaturalKeyOrPKMultipleChoiceFilter(
         queryset=Device.objects.all(),
         to_field_name="name",
         label="Device (name or ID)",
     )
-
 
     class Meta:
         model = models.BGPRoutingInstance

--- a/nautobot_bgp_models/tests/test_filters.py
+++ b/nautobot_bgp_models/tests/test_filters.py
@@ -531,7 +531,7 @@ class PeeringTestCase(FilterTestCases.FilterTestCase):
     )
 
     @classmethod
-    def setUpTestData(cls):  # pylint: disable=too-many-locals
+    def setUpTestData(cls):  # pylint: disable=too-many-statements,too-many-locals
         """One-time class setup to prepopulate required data for tests."""
         status_active = Status.objects.get(name__iexact="active")
         status_active.content_types.add(ContentType.objects.get_for_model(models.Peering))

--- a/nautobot_bgp_models/tests/test_filters.py
+++ b/nautobot_bgp_models/tests/test_filters.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 
 # from nautobot.circuits.models import Provider
 from nautobot.apps.testing import FilterTestCases
+from nautobot.circuits.models import Provider
 from nautobot.dcim.choices import InterfaceTypeChoices
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
 from nautobot.extras.models import Role, Status
@@ -12,11 +13,19 @@ from nautobot.ipam.models import VRF, IPAddress, Namespace, Prefix
 from nautobot_bgp_models import choices, filters, models
 
 
-class AutonomousSystemTestCase(FilterTestCases.BaseFilterTestCase):
+class AutonomousSystemTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of AutonomousSystem records."""
 
     queryset = models.AutonomousSystem.objects.all()
     filterset = filters.AutonomousSystemFilterSet
+
+    generic_filter_tests = (
+        ["asn"],
+        ["provider", "provider__id"],
+        ["provider", "provider__name"],
+        ["status", "status__id"],
+        ["status", "status__name"],
+    )
 
     @classmethod
     def setUpTestData(cls):
@@ -30,34 +39,29 @@ class AutonomousSystemTestCase(FilterTestCases.BaseFilterTestCase):
         cls.status_remote_asn = Status.objects.create(name="Remote ASN", color="FFFFFF")
         cls.status_remote_asn.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
 
+        provider_1 = Provider.objects.create(name="Test Provider1")
+        provider_2 = Provider.objects.create(name="Test Provider2")
+        provider_3 = Provider.objects.create(name="Test Provider3")
+
         models.AutonomousSystem.objects.create(
-            asn=4200000000, status=status_active, description="Reserved for private use"
+            asn=4200000000, status=status_active, provider=provider_1, description="Reserved for private use"
         )
         models.AutonomousSystem.objects.create(
-            asn=4200000001, status=cls.status_primary_asn, description="Also reserved for private use"
+            asn=4200000001,
+            status=cls.status_primary_asn,
+            provider=provider_2,
+            description="Also reserved for private use",
         )
         models.AutonomousSystem.objects.create(
-            asn=4200000002, status=cls.status_remote_asn, description="Another reserved for private use"
+            asn=4200000002,
+            status=cls.status_remote_asn,
+            provider=provider_3,
+            description="Another reserved for private use",
         )
 
         cls.asn_range = models.AutonomousSystemRange.objects.create(
             name="Private Use ASNs", asn_min=4200000001, asn_max=4294967295, description="Private Use Range"
         )
-
-    def test_id(self):
-        """Test filtering by ID (primary key)."""
-        params = {"id": self.queryset.values_list("pk", flat=True)[:2]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_asn(self):
-        """Test filtering by ASN."""
-        params = {"asn": [4200000000, 4200000001]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_status(self):
-        """Test filtering by status."""
-        params = {"status": [self.status_primary_asn.name, self.status_remote_asn.name]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_search(self):
         """Test filtering by Q search value."""
@@ -70,11 +74,17 @@ class AutonomousSystemTestCase(FilterTestCases.BaseFilterTestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class AutonomousSystemRangeTestCase(FilterTestCases.BaseFilterTestCase):
+class AutonomousSystemRangeTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of AutonomousSystemRange records."""
 
     queryset = models.AutonomousSystemRange.objects.all()
     filterset = filters.AutonomousSystemRangeFilterSet
+
+    generic_filter_tests = (
+        ["name"],
+        ["asn_min"],
+        ["asn_max"],
+    )
 
     @classmethod
     def setUpTestData(cls):
@@ -91,33 +101,104 @@ class AutonomousSystemRangeTestCase(FilterTestCases.BaseFilterTestCase):
             name="DC asns 2", asn_min=2001, asn_max=3000, description="asns for dc"
         )
 
-    def test_id(self):
-        """Test filtering by ID."""
-        params = {"id": self.queryset.values_list("pk", flat=True)[:2]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_name(self):
-        """Test filtering by Name."""
-        params = {"name": ["DC asns", "DC asns 2"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_min_max(self):
-        """Test filtering by ASN Min."""
-        params = {"asn_min": [1000]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
-        params = {"asn_max": [3000]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
-
     def test_search(self):
         """Test filtering by Q search value."""
         self.assertEqual(self.filterset({"q": "DC"}, self.queryset).qs.count(), 2)
 
 
-class PeerGroupTestCase(FilterTestCases.BaseFilterTestCase):
+class BGPRoutingInstanceTestCase(FilterTestCases.FilterTestCase):
+    """Test filtering of BGPRoutingInstance records."""
+
+    queryset = models.BGPRoutingInstance.objects.all()
+    filterset = filters.BGPRoutingInstanceFilterSet
+
+    generic_filter_tests = (
+        ["autonomous_system", "autonomous_system__asn"],
+        ["device", "device__name"],
+        ["device", "device__id"],
+    )
+
+    @classmethod
+    def setUpTestData(cls):  # pylint: disable=too-many-locals
+        """One-time class setup to prepopulate required data for tests."""
+
+        status_active = Status.objects.get(name__iexact="active")
+        status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
+        manufacturer = Manufacturer.objects.create(name="Cisco")
+        devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="CSR 1000V")
+        location_type = LocationType.objects.create(name="site")
+        location_status = Status.objects.get_for_model(Location).first()
+        location = Location.objects.create(name="Site 1", location_type=location_type, status=location_status)
+        devicerole = Role.objects.create(name="Router", color="ff0000")
+        devicerole.content_types.add(ContentType.objects.get_for_model(Device))
+
+        asn1 = models.AutonomousSystem.objects.create(asn=65000, status=status_active)
+        asn2 = models.AutonomousSystem.objects.create(asn=65001, status=status_active)
+        asn3 = models.AutonomousSystem.objects.create(asn=65002, status=status_active)
+
+        device_1 = Device.objects.create(
+            device_type=devicetype, role=devicerole, name="Device 1", location=location, status=status_active
+        )
+        device_2 = Device.objects.create(
+            device_type=devicetype, role=devicerole, name="Device 2", location=location, status=status_active
+        )
+        device_3 = Device.objects.create(
+            device_type=devicetype, role=devicerole, name="Device 3", location=location, status=status_active
+        )
+
+        namespace = Namespace.objects.first()
+        prefix_status = Status.objects.get_for_model(Prefix).first()
+        Prefix.objects.create(prefix="1.0.0.0/8", namespace=namespace, status=prefix_status)
+
+        router_id_1 = IPAddress.objects.create(address="1.1.1.1/32", status=status_active, namespace=namespace)
+        router_id_2 = IPAddress.objects.create(address="1.1.1.2/32", status=status_active, namespace=namespace)
+        router_id_3 = IPAddress.objects.create(address="1.1.1.3/32", status=status_active, namespace=namespace)
+
+        cls.bgp_instance_1 = models.BGPRoutingInstance.objects.create(
+            description="BGP routing instance for device 1",
+            device=device_1,
+            autonomous_system=asn1,
+            router_id=router_id_1,
+            status=status_active,
+        )
+
+        models.BGPRoutingInstance.objects.create(
+            description="BGP routing instance for device 2",
+            device=device_2,
+            autonomous_system=asn2,
+            router_id=router_id_2,
+            status=status_active,
+        )
+
+        models.BGPRoutingInstance.objects.create(
+            description="BGP routing instance for device 3",
+            device=device_3,
+            autonomous_system=asn3,
+            router_id=router_id_3,
+            status=status_active,
+        )
+
+    def test_search(self):
+        number_of_devices = models.BGPRoutingInstance.objects.filter(device=self.bgp_instance_1.device).count()
+        self.assertEqual(
+            self.filterset({"q": self.bgp_instance_1.device.name}, self.queryset).qs.count(), number_of_devices
+        )
+
+
+class PeerGroupTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of PeerGroup records."""
 
-    queryset = models.PeerGroup.objects.all()
     filterset = filters.PeerGroupFilterSet
+    queryset = models.PeerGroup.objects.all()
+
+    generic_filter_tests = (
+        ["name"],
+        ["autonomous_system", "autonomous_system__asn"],
+        ["routing_instance", "routing_instance__id"],
+        ["device", "routing_instance__device__name"],
+        ["device", "routing_instance__device__id"],
+        ["role"],
+    )
 
     @classmethod
     def setUpTestData(cls):
@@ -132,20 +213,27 @@ class PeerGroupTestCase(FilterTestCases.BaseFilterTestCase):
         location = Location.objects.create(name="Site 1", location_type=location_type, status=location_status)
         devicerole = Role.objects.create(name="Router", color="ff0000")
         devicerole.content_types.add(ContentType.objects.get_for_model(Device))
+
         cls.device_1 = Device.objects.create(
             device_type=devicetype, role=devicerole, name="Device 1", location=location, status=status_active
         )
         cls.device_2 = Device.objects.create(
             device_type=devicetype, role=devicerole, name="Device 2", location=location, status=status_active
         )
+        cls.device_3 = Device.objects.create(
+            device_type=devicetype, role=devicerole, name="Device 3", location=location, status=status_active
+        )
 
         cls.asn_1 = models.AutonomousSystem.objects.create(asn=4294967294, status=status_active)
         asn_2 = models.AutonomousSystem.objects.create(asn=4294967295, status=status_active)
+        asn_3 = models.AutonomousSystem.objects.create(asn=4294967296, status=status_active)
 
         cls.peeringrole_internal = Role.objects.create(name="Internal", color="333333")
         cls.peeringrole_internal.content_types.add(ContentType.objects.get_for_model(models.PeerGroup))
         peeringrole_external = Role.objects.create(name="External", color="ffffff")
         peeringrole_external.content_types.add(ContentType.objects.get_for_model(models.PeerGroup))
+        peeringrole_transit = Role.objects.create(name="Transit", color="0000ff")
+        peeringrole_transit.content_types.add(ContentType.objects.get_for_model(models.PeerGroup))
 
         cls.bgp_routing_instance_1 = models.BGPRoutingInstance.objects.create(
             description="Hello World!",
@@ -157,6 +245,12 @@ class PeerGroupTestCase(FilterTestCases.BaseFilterTestCase):
             description="Hello World!",
             autonomous_system=asn_2,
             device=cls.device_2,
+            status=status_active,
+        )
+        cls.bgp_routing_instance_3 = models.BGPRoutingInstance.objects.create(
+            description="Hello World!",
+            autonomous_system=asn_3,
+            device=cls.device_3,
             status=status_active,
         )
 
@@ -176,7 +270,7 @@ class PeerGroupTestCase(FilterTestCases.BaseFilterTestCase):
             description="External Group",
         )
         models.PeerGroup.objects.create(
-            routing_instance=cls.bgp_routing_instance_1,
+            routing_instance=cls.bgp_routing_instance_2,
             name="Group C",
             role=cls.peeringrole_internal,
             autonomous_system=asn_2,
@@ -184,10 +278,10 @@ class PeerGroupTestCase(FilterTestCases.BaseFilterTestCase):
             # vrf=cls.vrf
         )
         models.PeerGroup.objects.create(
-            routing_instance=cls.bgp_routing_instance_2,
+            routing_instance=cls.bgp_routing_instance_3,
             name="Group C",
-            role=cls.peeringrole_internal,
-            autonomous_system=asn_2,
+            role=peeringrole_transit,
+            autonomous_system=asn_3,
             description="Internal Group",
             # vrf=cls.vrf
         )
@@ -200,48 +294,98 @@ class PeerGroupTestCase(FilterTestCases.BaseFilterTestCase):
         self.assertEqual(self.filterset({"q": "Internal Group"}, self.queryset).qs.count(), 3)
         self.assertEqual(self.filterset({"q": "External Group"}, self.queryset).qs.count(), 1)
 
-    def test_id(self):
-        """Test filtering by ID (primary key)."""
-        params = {"id": self.queryset.values_list("pk", flat=True)[:2]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
     def test_enabled(self):
         """Test filtering by enabled status."""
         params = {"enabled": True}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
-    def test_device(self):
-        """Test filtering by device name."""
-        params = {"device": [self.device_1.name]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
-    def test_device_id(self):
-        """Test filtering by device ID."""
-        params = {"device_id": [self.device_1.id]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+class PeerGroupTemplateTestCase(FilterTestCases.FilterTestCase):
+    """Test filtering of BGPRoutingInstance records."""
 
-    def test_role(self):
-        """Test filtering by peering role."""
-        params = {"role": [self.peeringrole_internal.name]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+    filterset = filters.PeerGroupTemplateFilterSet
+    queryset = models.PeerGroupTemplate.objects.all()
 
-    def test_autonomous_system(self):
-        """Test filtering by autonomous system."""
-        params = {"autonomous_system": [4294967294]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+    generic_filter_tests = (
+        ["name"],
+        ["autonomous_system", "autonomous_system__asn"],
+    )
 
-    def test_routing_instance(self):
-        """Test Routing Instance."""
+    @classmethod
+    def setUpTestData(cls):
+        """One-time class setup to prepopulate required data for tests."""
+
+        status_active = Status.objects.get(name__iexact="active")
+        status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
+        asn1 = models.AutonomousSystem.objects.create(asn=65000, status=status_active)
+        asn2 = models.AutonomousSystem.objects.create(asn=65001, status=status_active)
+        asn3 = models.AutonomousSystem.objects.create(asn=65002, status=status_active)
+
+        role_internal = Role.objects.create(name="Internal", color="ffffff")
+        role_internal.content_types.add(ContentType.objects.get_for_model(models.PeerGroupTemplate))
+        role_external = Role.objects.create(name="External", color="ffffff")
+        role_external.content_types.add(ContentType.objects.get_for_model(models.PeerGroupTemplate))
+        role_transit = Role.objects.create(name="Transit", color="ffffff")
+        role_transit.content_types.add(ContentType.objects.get_for_model(models.PeerGroupTemplate))
+
+        cls.peer_group_template_1 = models.PeerGroupTemplate.objects.create(
+            name="Template 1",
+            role=role_internal,
+            description="Hello World",
+            autonomous_system=asn1,
+        )
+
+        cls.peer_group_template_2 = models.PeerGroupTemplate.objects.create(
+            name="Template 2",
+            role=role_external,
+            description="This is a Peer Group Template",
+            autonomous_system=asn2,
+        )
+
+        models.PeerGroupTemplate.objects.create(
+            name="Template 3",
+            role=role_transit,
+            description="Hello World",
+            enabled=False,
+            autonomous_system=asn3,
+        )
+
+    def test_enabled(self):
+        """Test filtering by enabled status."""
+        number_enabled = models.PeerGroupTemplate.objects.filter(enabled=True).count()
+        self.assertEqual(self.filterset({"enabled": True}, self.queryset).qs.count(), number_enabled)
+
+    def test_search(self):
+        """Test filtering by Q search value."""
+        number_of_instances_with_name = models.PeerGroupTemplate.objects.filter(
+            name=self.peer_group_template_1.name
+        ).count()
+        number_of_instances_with_description = models.PeerGroupTemplate.objects.filter(
+            description=self.peer_group_template_2.description
+        ).count()
         self.assertEqual(
-            self.filterset({"routing_instance": [self.bgp_routing_instance_1.pk]}, self.queryset).qs.count(), 3
+            self.filterset({"q": self.peer_group_template_1.name}, self.queryset).qs.count(),
+            number_of_instances_with_name,
+        )
+        self.assertEqual(
+            self.filterset({"q": self.peer_group_template_2.description}, self.queryset).qs.count(),
+            number_of_instances_with_description,
         )
 
 
-class PeerEndpointTestCase(FilterTestCases.BaseFilterTestCase):
+class PeerEndpointTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of PeerEndpoint records."""
 
     queryset = models.PeerEndpoint.objects.all()
     filterset = filters.PeerEndpointFilterSet
+
+    generic_filter_tests = (
+        ["device", "routing_instance__device__name"],
+        ["device", "routing_instance__device__id"],
+        ["autonomous_system", "autonomous_system__asn"],
+        ["peer_group", "peer_group__id"],
+        ["peer_group", "peer_group__name"],
+    )
 
     @classmethod
     def setUpTestData(cls):  # pylint: disable=too-many-locals
@@ -249,11 +393,9 @@ class PeerEndpointTestCase(FilterTestCases.BaseFilterTestCase):
         status_active = Status.objects.get(name__iexact="active")
         status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
 
-        # provider = Provider.objects.create(name="Provider", slug="provider")
-
-        asn = models.AutonomousSystem.objects.create(asn=4294967295, status=status_active)
-        # asn_15521 = models.AutonomousSystem.objects.create(asn=15521, status=status_active, provider=provider)
-
+        asn_1 = models.AutonomousSystem.objects.create(asn=4294967295, status=status_active)
+        asn_2 = models.AutonomousSystem.objects.create(asn=4294967296, status=status_active)
+        asn_3 = models.AutonomousSystem.objects.create(asn=4294967297, status=status_active)
         peeringrole = Role.objects.create(name="Internal", color="ffffff")
         peeringrole.content_types.add(ContentType.objects.get_for_model(models.PeerGroup))
         manufacturer = Manufacturer.objects.create(name="Cisco")
@@ -263,16 +405,30 @@ class PeerEndpointTestCase(FilterTestCases.BaseFilterTestCase):
         cls.location = Location.objects.create(name="Site 1", location_type=location_type, status=location_status)
         cls.devicerole = Role.objects.create(name="Router", color="ff0000")
         cls.devicerole.content_types.add(ContentType.objects.get_for_model(Device))
-        cls.device = Device.objects.create(
+        device_1 = Device.objects.create(
             device_type=cls.devicetype,
             role=cls.devicerole,
             name="Device 1",
             location=cls.location,
             status=status_active,
         )
+        device_2 = Device.objects.create(
+            device_type=cls.devicetype,
+            role=cls.devicerole,
+            name="Device 2",
+            location=cls.location,
+            status=status_active,
+        )
+        device_3 = Device.objects.create(
+            device_type=cls.devicetype,
+            role=cls.devicerole,
+            name="Device 3",
+            location=cls.location,
+            status=status_active,
+        )
         interface_status = Status.objects.get_for_model(Interface).first()
         interface = Interface.objects.create(
-            device=cls.device, name="Loopback1", type=InterfaceTypeChoices.TYPE_VIRTUAL, status=interface_status
+            device=device_1, name="Loopback1", type=InterfaceTypeChoices.TYPE_VIRTUAL, status=interface_status
         )
 
         namespace = Namespace.objects.first()
@@ -287,17 +443,39 @@ class PeerEndpointTestCase(FilterTestCases.BaseFilterTestCase):
 
         interface.add_ip_addresses([addresses[0], addresses[1]])
 
-        cls.bgp_routing_instance = models.BGPRoutingInstance.objects.create(
+        bgp_routing_instance_1 = models.BGPRoutingInstance.objects.create(
             description="Hello World!",
-            autonomous_system=asn,
-            device=cls.device,
+            autonomous_system=asn_1,
+            device=device_1,
+            status=status_active,
+        )
+        bgp_routing_instance_2 = models.BGPRoutingInstance.objects.create(
+            description="Hello World!",
+            autonomous_system=asn_2,
+            device=device_2,
+            status=status_active,
+        )
+        bgp_routing_instance_3 = models.BGPRoutingInstance.objects.create(
+            description="Hello World!",
+            autonomous_system=asn_3,
+            device=device_3,
             status=status_active,
         )
 
-        cls.peergroup = models.PeerGroup.objects.create(
+        peergroup_1 = models.PeerGroup.objects.create(
             name="Group B",
             role=peeringrole,
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=bgp_routing_instance_1,
+        )
+        peergroup_2 = models.PeerGroup.objects.create(
+            name="Group C",
+            role=peeringrole,
+            routing_instance=bgp_routing_instance_2,
+        )
+        peergroup_3 = models.PeerGroup.objects.create(
+            name="Group D",
+            role=peeringrole,
+            routing_instance=bgp_routing_instance_3,
         )
 
         peering1 = models.Peering.objects.create(status=status_active)
@@ -305,76 +483,65 @@ class PeerEndpointTestCase(FilterTestCases.BaseFilterTestCase):
         peering3 = models.Peering.objects.create(status=status_active)
 
         models.PeerEndpoint.objects.create(
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=bgp_routing_instance_1,
             source_ip=addresses[0],
-            autonomous_system=asn,
+            autonomous_system=asn_1,
+            peer_group=peergroup_1,
             peering=peering1,
         )
         models.PeerEndpoint.objects.create(
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=bgp_routing_instance_2,
             source_ip=addresses[1],
-            autonomous_system=asn,
-            peer_group=cls.peergroup,
+            autonomous_system=asn_2,
+            peer_group=peergroup_2,
             peering=peering2,
         )
         models.PeerEndpoint.objects.create(
+            routing_instance=bgp_routing_instance_3,
             source_ip=addresses[2],
-            peer_group=cls.peergroup,
+            autonomous_system=asn_3,
+            peer_group=peergroup_3,
             enabled=False,
             peering=peering3,
         )
 
     def test_search(self):
         """Test text search."""
-        self.assertEqual(self.filterset({"q": "dev"}, self.queryset).qs.count(), 2)
-
-    def test_id(self):
-        """Test filtering by ID (primary key)."""
-        params = {"id": self.queryset.values_list("pk", flat=True)[:2]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset({"q": "device 1"}, self.queryset).qs.count(), 1)
 
     def test_enabled(self):
         """Test filtering by enabled status."""
         params = {"enabled": True}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_autonomous_system(self):
-        """Test filtering by autonomous system."""
-        params = {"autonomous_system": [4294967295]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_peer_group(self):
-        """Test filtering by peer-group."""
-        params = {"peer_group": [self.peergroup.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_device(self):
-        """Test filtering by device name."""
-        params = {"device": ["Device 1"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_device_id(self):
-        """Test filtering by device ID."""
-        params = {"device_id": [self.device.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-
-class PeeringTestCase(FilterTestCases.BaseFilterTestCase):
+class PeeringTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of Peering records."""
 
     queryset = models.Peering.objects.all()
     filterset = filters.PeeringFilterSet
 
+    generic_filter_tests = (
+        ["status", "status__id"],
+        ["status", "status__name"],
+        ["device", "endpoints__routing_instance__device__name"],
+        ["device", "endpoints__routing_instance__device__id"],
+        ["device_role", "endpoints__routing_instance__device__role__name"],
+        ["peer_endpoint_role", "endpoints__role__name"],
+    )
+
     @classmethod
     def setUpTestData(cls):  # pylint: disable=too-many-locals
         """One-time class setup to prepopulate required data for tests."""
         status_active = Status.objects.get(name__iexact="active")
-        cls.status_active = status_active
         status_active.content_types.add(ContentType.objects.get_for_model(models.Peering))
         status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
 
         status_reserved = Status.objects.get(name__iexact="reserved")
         status_reserved.content_types.add(ContentType.objects.get_for_model(models.Peering))
+
+        status_planned = Status.objects.get(name__iexact="planned")
+        status_planned.content_types.add(ContentType.objects.get_for_model(models.Peering))
 
         asn1 = models.AutonomousSystem.objects.create(asn=65000, status=status_active)
         asn2 = models.AutonomousSystem.objects.create(asn=66000, status=status_active)
@@ -387,43 +554,96 @@ class PeeringTestCase(FilterTestCases.BaseFilterTestCase):
         location = Location.objects.create(name="Site 1", location_type=location_type, status=location_status)
         devicerole_router = Role.objects.create(name="Router", color="ff0000")
         devicerole_switch = Role.objects.create(name="Switch", color="ff0000")
-        cls.device1 = Device.objects.create(
+        devicerole_firewall = Role.objects.create(name="Firewall", color="ff0000")
+        device_1 = Device.objects.create(
             device_type=devicetype,
             role=devicerole_router,
-            name="device1",
+            name="device 1",
             location=location,
             status=status_active,
         )
-        cls.device2 = Device.objects.create(
+        device_2 = Device.objects.create(
             device_type=devicetype,
             role=devicerole_switch,
-            name="device2",
+            name="device 2",
             location=location,
             status=status_active,
         )
-        cls.bgp_routing_instance = models.BGPRoutingInstance.objects.create(
-            description="Device 1 RI",
-            autonomous_system=asn1,
-            device=cls.device1,
+        device_3 = Device.objects.create(
+            device_type=devicetype,
+            role=devicerole_firewall,
+            name="device 3",
+            location=location,
+            status=status_active,
+        )
+        device_4 = Device.objects.create(
+            device_type=devicetype,
+            role=devicerole_firewall,
+            name="device 4",
+            location=location,
+            status=status_active,
+        )
+        device_5 = Device.objects.create(
+            device_type=devicetype,
+            role=devicerole_firewall,
+            name="device 5",
+            location=location,
+            status=status_active,
+        )
+        device_6 = Device.objects.create(
+            device_type=devicetype,
+            role=devicerole_firewall,
+            name="device 6",
+            location=location,
             status=status_active,
         )
 
-        cls.bgp_routing_instance_device_2 = models.BGPRoutingInstance.objects.create(
+        bgp_routing_instance_device_1 = models.BGPRoutingInstance.objects.create(
+            description="Device 1 RI",
+            autonomous_system=asn1,
+            device=device_1,
+            status=status_active,
+        )
+        bgp_routing_instance_device_2 = models.BGPRoutingInstance.objects.create(
             description="Device 2 RI",
             autonomous_system=asn1,
-            device=cls.device2,
+            device=device_2,
+            status=status_active,
+        )
+        bgp_routing_instance_device_3 = models.BGPRoutingInstance.objects.create(
+            description="Device 3 RI",
+            autonomous_system=asn1,
+            device=device_3,
+            status=status_active,
+        )
+        bgp_routing_instance_device_4 = models.BGPRoutingInstance.objects.create(
+            description="Device 4 RI",
+            autonomous_system=asn1,
+            device=device_4,
+            status=status_active,
+        )
+        bgp_routing_instance_device_5 = models.BGPRoutingInstance.objects.create(
+            description="Device 5 RI",
+            autonomous_system=asn1,
+            device=device_5,
+            status=status_active,
+        )
+        bgp_routing_instance_device_6 = models.BGPRoutingInstance.objects.create(
+            description="Device 6 RI",
+            autonomous_system=asn1,
+            device=device_6,
             status=status_active,
         )
 
         interface_status = Status.objects.get_for_model(Interface).first()
         interfaces_device1 = [
-            Interface.objects.create(device=cls.device1, name="Loopback0", status=interface_status),
-            Interface.objects.create(device=cls.device1, name="Loopback1", status=interface_status),
-            Interface.objects.create(device=cls.device1, name="Loopback2", status=interface_status),
+            Interface.objects.create(device=device_1, name="Loopback0", status=interface_status),
+            Interface.objects.create(device=device_1, name="Loopback1", status=interface_status),
+            Interface.objects.create(device=device_1, name="Loopback2", status=interface_status),
         ]
         interfaces_device2 = [
-            Interface.objects.create(device=cls.device2, name="Loopback0", status=interface_status),
-            Interface.objects.create(device=cls.device2, name="Loopback1", status=interface_status),
+            Interface.objects.create(device=device_2, name="Loopback0", status=interface_status),
+            Interface.objects.create(device=device_2, name="Loopback1", status=interface_status),
         ]
 
         namespace = Namespace.objects.first()
@@ -490,24 +710,20 @@ class PeeringTestCase(FilterTestCases.BaseFilterTestCase):
         interfaces_device2[0].add_ip_addresses(addresses[6])
         interfaces_device2[1].add_ip_addresses(addresses[8])
 
-        # peeringrole_internal = models.PeeringRole.objects.create(name="Internal", slug="internal", color="ffffff")
-        # peeringrole_external = models.PeeringRole.objects.create(name="External", slug="external", color="ffffff")
         peeringrole_internal = Role.objects.create(name="Internal", color="ffffff")
         peeringrole_internal.content_types.add(ContentType.objects.get_for_model(models.PeerEndpoint))
         peeringrole_external = Role.objects.create(name="External", color="ffffff")
         peeringrole_external.content_types.add(ContentType.objects.get_for_model(models.PeerEndpoint))
+        peeringrole_transit = Role.objects.create(name="Transit", color="ffffff")
+        peeringrole_transit.content_types.add(ContentType.objects.get_for_model(models.PeerEndpoint))
 
         peerings = [
             # Peering #0
             models.Peering.objects.create(status=status_active),
             # Peering #1
-            models.Peering.objects.create(status=status_active),
-            # Peering #2
             models.Peering.objects.create(status=status_reserved),
-            # Peering #3
-            models.Peering.objects.create(status=status_active),
-            # Peering #4
-            models.Peering.objects.create(status=status_active),
+            # Peering #2
+            models.Peering.objects.create(status=status_planned),
         ]
 
         # Peering #0
@@ -516,13 +732,13 @@ class PeeringTestCase(FilterTestCases.BaseFilterTestCase):
             peering=peerings[0],
             autonomous_system=asn1,
             role=peeringrole_internal,
-            routing_instance=cls.bgp_routing_instance,
+            routing_instance=bgp_routing_instance_device_1,
         )
         models.PeerEndpoint.objects.create(
             source_ip=addresses[1],
             peering=peerings[0],
             autonomous_system=asn1,
-            role=peeringrole_external,
+            routing_instance=bgp_routing_instance_device_4,
         )
 
         # Peering #1
@@ -530,14 +746,14 @@ class PeeringTestCase(FilterTestCases.BaseFilterTestCase):
             source_ip=addresses[2],
             peering=peerings[1],
             autonomous_system=asn1,
-            role=peeringrole_internal,
-            routing_instance=cls.bgp_routing_instance,
+            role=peeringrole_external,
+            routing_instance=bgp_routing_instance_device_2,
         )
         models.PeerEndpoint.objects.create(
             source_ip=addresses[3],
             peering=peerings[1],
             autonomous_system=asn2,
-            role=peeringrole_external,
+            routing_instance=bgp_routing_instance_device_5,
         )
 
         # Peering #2
@@ -545,104 +761,20 @@ class PeeringTestCase(FilterTestCases.BaseFilterTestCase):
             source_ip=addresses[4],
             peering=peerings[2],
             autonomous_system=asn1,
-            role=peeringrole_internal,
-            routing_instance=cls.bgp_routing_instance,
+            role=peeringrole_transit,
+            routing_instance=bgp_routing_instance_device_3,
         )
         models.PeerEndpoint.objects.create(
             source_ip=addresses[5],
             peering=peerings[2],
             autonomous_system=asn3,
-            role=peeringrole_external,
+            routing_instance=bgp_routing_instance_device_6,
         )
 
-        # Peering #3
-        models.PeerEndpoint.objects.create(
-            source_ip=addresses[6],
-            peering=peerings[3],
-            autonomous_system=asn1,
-            role=peeringrole_internal,
-            routing_instance=cls.bgp_routing_instance_device_2,
-        )
-        models.PeerEndpoint.objects.create(
-            source_ip=addresses[7],
-            peering=peerings[3],
-            autonomous_system=asn3,
-            role=peeringrole_external,
-        )
-
-        # Peering #4
-        models.PeerEndpoint.objects.create(
-            source_ip=addresses[8],
-            peering=peerings[4],
-            autonomous_system=asn1,
-            role=peeringrole_internal,
-            routing_instance=cls.bgp_routing_instance_device_2,
-        )
-        models.PeerEndpoint.objects.create(
-            source_ip=addresses[9],
-            peering=peerings[4],
-            autonomous_system=asn3,
-            role=peeringrole_external,
-        )
-
-    def test_id(self):
-        """Test filtering by id."""
-        params = {"id": self.queryset.values_list("pk", flat=True)[:2]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    # def test_role(self):
-    #     """Test filtering by role."""
-    #     params = {"role": ["external"]}
-    #     self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_status(self):
-        """Test filtering by status."""
-        params = {"status": [self.status_active.name]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
-
-    def test_device(self):
-        """Test filtering by device name."""
-        params = {"device": ["device1"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
-
-        params = {"device": ["device2"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-        params = {"device": ["device1", "device2"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
-
-    def test_device_id(self):
-        """Test filtering by device id."""
-        params = {"device_id": [self.device1.id]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
-
-        params = {"device_id": [self.device2.id]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-        params = {"device_id": [self.device1.pk, self.device2.id]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
-
-    def test_device_role(self):
-        """Test filtering by device role name."""
-        params = {"device_role": ["Router"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
-
-        params = {"device_role": ["Switch"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-        params = {"device_role": ["Router", "Switch"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
-
-    def test_peer_endpoint_role(self):
-        """Test filtering by peer endpoint role name."""
-        params = {"peer_endpoint_role": ["internal"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
-
-        params = {"peer_endpoint_role": ["external"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
-
-        params = {"peer_endpoint_role": ["router", "switch"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+    def test_search(self):
+        """Test filtering by Q search value."""
+        self.assertEqual(self.filterset({"q": "device 2"}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"q": "device 3"}, self.queryset).qs.count(), 1)
 
     # def test_asn(self):
     #     """Test filtering by asn name."""
@@ -673,17 +805,20 @@ class PeeringTestCase(FilterTestCases.BaseFilterTestCase):
     #     params = {"address": ["10.1.1.3", "10.1.1.5"]}
     #     self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_search(self):
-        """Test filtering by Q search value."""
-        self.assertEqual(self.filterset({"q": "device1"}, self.queryset).qs.count(), 3)
-        self.assertEqual(self.filterset({"q": "device2"}, self.queryset).qs.count(), 2)
 
-
-class AddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
+class AddressFamilyTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of AddressFamily records."""
 
     queryset = models.AddressFamily.objects.all()
     filterset = filters.AddressFamilyFilterSet
+
+    generic_filter_tests = (
+        ["vrf"],
+        ["afi_safi"],
+        ["routing_instance", "routing_instance__id"],
+        ["device", "routing_instance__device__name"],
+        ["device", "routing_instance__device__id"],
+    )
 
     @classmethod
     def setUpTestData(cls):  # pylint: disable=too-many-locals
@@ -702,6 +837,9 @@ class AddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
         device2 = Device.objects.create(
             device_type=devicetype, role=devicerole, name="Router-8", location=location, status=status_active
         )
+        device3 = Device.objects.create(
+            device_type=devicetype, role=devicerole, name="Switch-1", location=location, status=status_active
+        )
         interface_status = Status.objects.get_for_model(Interface).first()
         interface = Interface.objects.create(device=device1, name="Loopback1", status=interface_status)
 
@@ -718,82 +856,62 @@ class AddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
 
         asn1 = models.AutonomousSystem.objects.create(asn=65000, status=status_active)
 
-        cls.bgp_routing_instance1 = models.BGPRoutingInstance.objects.create(
+        bgp_routing_instance1 = models.BGPRoutingInstance.objects.create(
             description="Hello World!",
             autonomous_system=asn1,
             device=device1,
             status=status_active,
         )
-        cls.bgp_routing_instance2 = models.BGPRoutingInstance.objects.create(
+        bgp_routing_instance2 = models.BGPRoutingInstance.objects.create(
             description="Hello World!",
             autonomous_system=asn1,
             device=device2,
             status=status_active,
         )
-
-        cls.peergroup = models.PeerGroup.objects.create(
-            routing_instance=cls.bgp_routing_instance1,
-            name="Group B",
-            role=peeringrole,
+        bgp_routing_instance3 = models.BGPRoutingInstance.objects.create(
+            description="Hello World!",
+            autonomous_system=asn1,
+            device=device3,
+            status=status_active,
         )
 
-        peering = models.Peering.objects.create(status=status_active)
-        cls.endpoint = models.PeerEndpoint.objects.create(
-            routing_instance=cls.bgp_routing_instance1,
-            source_ip=address,
-            peering=peering,
-        )
-
-        cls.vrf = VRF.objects.create(name="VRF 1", rd="65000:1", status=status_active)
+        vrf_1 = VRF.objects.create(name="VRF 1", rd="65000:1", status=status_active)
+        vrf_2 = VRF.objects.create(name="VRF 2", rd="65000:100", status=status_active)
+        vrf_3 = VRF.objects.create(name="VRF 3", rd="65000:200", status=status_active)
 
         models.AddressFamily.objects.create(
-            routing_instance=cls.bgp_routing_instance1,
+            routing_instance=bgp_routing_instance1,
             afi_safi=choices.AFISAFIChoices.AFI_IPV4_UNICAST,
-            vrf=cls.vrf,
+            vrf=vrf_1,
         )
 
         models.AddressFamily.objects.create(
-            routing_instance=cls.bgp_routing_instance1,
-            afi_safi=choices.AFISAFIChoices.AFI_IPV4_FLOWSPEC,
+            routing_instance=bgp_routing_instance2, afi_safi=choices.AFISAFIChoices.AFI_IPV4_FLOWSPEC, vrf=vrf_2
         )
 
         models.AddressFamily.objects.create(
-            routing_instance=cls.bgp_routing_instance2,
-            afi_safi=choices.AFISAFIChoices.AFI_VPNV4_UNICAST,
+            routing_instance=bgp_routing_instance3, afi_safi=choices.AFISAFIChoices.AFI_VPNV4_UNICAST, vrf=vrf_3
         )
-
-    def test_id(self):
-        """Test filtering by id."""
-        params = {"id": self.queryset.values_list("pk", flat=True)[:2]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_afi_safi(self):
-        """Test filtering by AFI-SAFI."""
-        params = {"afi_safi": ["ipv4_unicast", "vpnv4_unicast"]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    # TODO filtering by device/virtualmachine
-    def test_device(self):
-        pass
 
     def test_search(self):
         """Test filtering by Q search value."""
-        self.assertEqual(self.filterset({"q": "dev"}, self.queryset).qs.count(), 2)
-
-    def test_vrf(self):
-        """Test filtering by VRF."""
-        params = {"vrf": [self.vrf.pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"q": "rout"}, self.queryset).qs.count(), 1)
 
 
-class PeerGroupAddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
+class PeerGroupAddressFamilyTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of PeerGroupAddressFamily records."""
 
     queryset = models.PeerGroupAddressFamily.objects.all()
     filterset = filters.PeerGroupAddressFamilyFilterSet
 
+    generic_filter_tests = (
+        ["afi_safi"],
+        ["peer_group", "peer_group__id"],
+        ["peer_group", "peer_group__name"],
+    )
+
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # pylint: disable=too-many-statements
         """One-time class setup."""
         status_active = Status.objects.get(name__iexact="active")
         status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
@@ -825,14 +943,14 @@ class PeerGroupAddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
             status=status_active,
         )
 
-        cls.pg1 = models.PeerGroup.objects.create(
+        cls.peergroup_1 = models.PeerGroup.objects.create(
             routing_instance=cls.bgp_routing_instance,
             name="Group A",
             role=cls.peeringrole_internal,
             autonomous_system=cls.asn_1,
             description="Internal Group",
         )
-        cls.pg2 = models.PeerGroup.objects.create(
+        peergroup_2 = models.PeerGroup.objects.create(
             routing_instance=cls.bgp_routing_instance,
             name="Group B",
             role=peeringrole_external,
@@ -840,47 +958,45 @@ class PeerGroupAddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
             enabled=False,
             description="External Group",
         )
+        peergroup_3 = models.PeerGroup.objects.create(
+            routing_instance=cls.bgp_routing_instance,
+            name="Group C",
+            role=peeringrole_external,
+            autonomous_system=cls.asn_1,
+            enabled=False,
+            description="External Group",
+        )
 
         models.PeerGroupAddressFamily.objects.create(
-            peer_group=cls.pg1,
+            peer_group=cls.peergroup_1,
             afi_safi="ipv4_unicast",
         )
         models.PeerGroupAddressFamily.objects.create(
-            peer_group=cls.pg1,
+            peer_group=peergroup_2,
             afi_safi="ipv6_unicast",
         )
         models.PeerGroupAddressFamily.objects.create(
-            peer_group=cls.pg2,
-            afi_safi="ipv4_unicast",
+            peer_group=peergroup_3,
+            afi_safi="ipv4_multicast",
         )
 
     def test_search(self):
         """Test text search."""
         self.assertEqual(self.filterset({"q": "ipv4"}, self.queryset).qs.count(), 2)
-        self.assertEqual(self.filterset({"q": self.pg1.name}, self.queryset).qs.count(), 2)
-        self.assertEqual(self.filterset({"q": self.pg1.description}, self.queryset).qs.count(), 2)
-
-    def test_id(self):
-        """Test filtering by ID (primary key)."""
-        self.assertEqual(
-            self.filterset({"id": self.queryset.values_list("pk", flat=True)[:2]}, self.queryset).qs.count(),
-            2,
-        )
-
-    def test_afi_safi(self):
-        """Test filtering by afi_safi."""
-        self.assertEqual(self.filterset({"afi_safi": ["ipv4_unicast"]}, self.queryset).qs.count(), 2)
-
-    def test_peer_endpoint(self):
-        """Test filtering by peer_group."""
-        self.assertEqual(self.filterset({"peer_group": [self.pg1.pk]}, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset({"q": self.peergroup_1.name}, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset({"q": self.peergroup_1.description}, self.queryset).qs.count(), 1)
 
 
-class PeerEndpointAddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
+class PeerEndpointAddressFamilyTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of PeerEndpointAddressFamily records."""
 
     queryset = models.PeerEndpointAddressFamily.objects.all()
     filterset = filters.PeerEndpointAddressFamilyFilterSet
+
+    generic_filter_tests = (
+        ["afi_safi"],
+        ["peer_endpoint", "peer_endpoint__id"],
+    )
 
     @classmethod
     def setUpTestData(cls):
@@ -989,26 +1105,11 @@ class PeerEndpointAddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
         )
         models.PeerEndpointAddressFamily.objects.create(
             peer_endpoint=cls.pe3,
-            afi_safi="ipv4_unicast",
+            afi_safi="ipv4_multicast",
         )
 
     def test_search(self):
         """Test text search."""
-        self.assertEqual(self.filterset({"q": "ipv4_uni"}, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset({"q": "ipv4_uni"}, self.queryset).qs.count(), 2)
         self.assertEqual(self.filterset({"q": "endpoint"}, self.queryset).qs.count(), 2)
         self.assertEqual(self.filterset({"q": "dev"}, self.queryset).qs.count(), 3)
-
-    def test_id(self):
-        """Test filtering by ID (primary key)."""
-        self.assertEqual(
-            self.filterset({"id": self.queryset.values_list("pk", flat=True)[:2]}, self.queryset).qs.count(),
-            2,
-        )
-
-    def test_afi_safi(self):
-        """Test filtering by AFI-SAFI."""
-        self.assertEqual(self.filterset({"afi_safi": ["ipv4_unicast"]}, self.queryset).qs.count(), 3)
-
-    def test_peer_endpoint(self):
-        """Test filtering by peer_endpoint."""
-        self.assertEqual(self.filterset({"peer_endpoint": [self.pe1.pk, self.pe2.pk]}, self.queryset).qs.count(), 3)

--- a/nautobot_bgp_models/tests/test_filters.py
+++ b/nautobot_bgp_models/tests/test_filters.py
@@ -9,6 +9,8 @@ from nautobot.dcim.choices import InterfaceTypeChoices
 from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
 from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import VRF, IPAddress, Namespace, Prefix
+from nautobot.tenancy.models import Tenant
+
 
 from nautobot_bgp_models import choices, filters, models
 
@@ -20,6 +22,7 @@ class AutonomousSystemTestCase(FilterTestCases.FilterTestCase):
     filterset = filters.AutonomousSystemFilterSet
 
     generic_filter_tests = (
+        ["description"],
         ["asn"],
         ["provider", "provider__id"],
         ["provider", "provider__name"],
@@ -44,7 +47,10 @@ class AutonomousSystemTestCase(FilterTestCases.FilterTestCase):
         provider_3 = Provider.objects.create(name="Test Provider3")
 
         models.AutonomousSystem.objects.create(
-            asn=4200000000, status=status_active, provider=provider_1, description="Reserved for private use"
+            asn=4200000000, 
+            status=status_active, 
+            provider=provider_1, 
+            description="Reserved for private use",
         )
         models.AutonomousSystem.objects.create(
             asn=4200000001,
@@ -84,21 +90,28 @@ class AutonomousSystemRangeTestCase(FilterTestCases.FilterTestCase):
         ["name"],
         ["asn_min"],
         ["asn_max"],
+        ["description"],
+        ["tenant", "tenant__name"],
+        ["tenant", "tenant__id"],
     )
 
     @classmethod
     def setUpTestData(cls):
         """One-time class setup to prepopulate required data for tests."""
+        tenant1 = Tenant.objects.create(name="Tenant-1")
+        tenant2 = Tenant.objects.create(name="Tenant-2")
+        tenant3 = Tenant.objects.create(name="Tenant-3")
+
         cls.asn_range_1 = models.AutonomousSystemRange.objects.create(
-            name="Public asns", asn_min=100, asn_max=125, description="Test Range 1"
+            name="Public asns", asn_min=100, asn_max=125, tenant=tenant1, description="Test Range 1"
         )
 
         cls.asn_range_2 = models.AutonomousSystemRange.objects.create(
-            name="DC asns", asn_min=1000, asn_max=2000, description="asns for dc"
+            name="DC asns", asn_min=1000, asn_max=2000, tenant=tenant2, description="asns for dc"
         )
 
         cls.asn_range_3 = models.AutonomousSystemRange.objects.create(
-            name="DC asns 2", asn_min=2001, asn_max=3000, description="asns for dc"
+            name="DC asns 2", asn_min=2001, asn_max=3000, tenant=tenant3, description="Hello World"
         )
 
     def test_search(self):
@@ -113,9 +126,13 @@ class BGPRoutingInstanceTestCase(FilterTestCases.FilterTestCase):
     filterset = filters.BGPRoutingInstanceFilterSet
 
     generic_filter_tests = (
+        ["description"],
         ["autonomous_system", "autonomous_system__asn"],
         ["device", "device__name"],
         ["device", "device__id"],
+        ["device_id", "device__id"],  #TODO: Remove this when deprecated `device_id` filter id removed
+        ["status", "status__id"],
+        ["status", "status__name"],
     )
 
     @classmethod
@@ -124,6 +141,13 @@ class BGPRoutingInstanceTestCase(FilterTestCases.FilterTestCase):
 
         status_active = Status.objects.get(name__iexact="active")
         status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
+
+        status_reserved = Status.objects.get(name__iexact="reserved")
+        status_reserved.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
+
+        status_planned = Status.objects.get(name__iexact="planned")
+        status_planned.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
+
         manufacturer = Manufacturer.objects.create(name="Cisco")
         devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="CSR 1000V")
         location_type = LocationType.objects.create(name="site")
@@ -167,7 +191,7 @@ class BGPRoutingInstanceTestCase(FilterTestCases.FilterTestCase):
             device=device_2,
             autonomous_system=asn2,
             router_id=router_id_2,
-            status=status_active,
+            status=status_reserved,
         )
 
         models.BGPRoutingInstance.objects.create(
@@ -175,7 +199,7 @@ class BGPRoutingInstanceTestCase(FilterTestCases.FilterTestCase):
             device=device_3,
             autonomous_system=asn3,
             router_id=router_id_3,
-            status=status_active,
+            status=status_planned,
         )
 
     def test_search(self):
@@ -193,11 +217,14 @@ class PeerGroupTestCase(FilterTestCases.FilterTestCase):
 
     generic_filter_tests = (
         ["name"],
+        ["role"],
+        ["vrf"],
+        ["description"],
         ["autonomous_system", "autonomous_system__asn"],
         ["routing_instance", "routing_instance__id"],
         ["device", "routing_instance__device__name"],
         ["device", "routing_instance__device__id"],
-        ["role"],
+        ["device_id", "routing_instance__device__id"],  #TODO: Remove this when deprecated `device_id` filter id removed
     )
 
     @classmethod
@@ -254,12 +281,28 @@ class PeerGroupTestCase(FilterTestCases.FilterTestCase):
             status=status_active,
         )
 
+        vrf_1 = VRF.objects.create(name="VRF 1", rd="65000:1", status=status_active)
+        vrf_2 = VRF.objects.create(name="VRF 2", rd="65000:100", status=status_active)
+        vrf_3 = VRF.objects.create(name="VRF 3", rd="65000:200", status=status_active)
+
+        namespace = Namespace.objects.first()
+        prefix_status = Status.objects.get_for_model(Prefix).first()
+        Prefix.objects.create(prefix="1.0.0.0/8", namespace=namespace, status=prefix_status)
+
+        
+        source_ip_1 = IPAddress.objects.create(address="1.1.1.1/32", status=status_active, namespace=namespace)
+        source_ip_2 = IPAddress.objects.create(address="1.1.1.2/32", status=status_active, namespace=namespace)
+        source_ip_3 = IPAddress.objects.create(address="1.1.1.3/32", status=status_active, namespace=namespace)
+        
+
         models.PeerGroup.objects.create(
             routing_instance=cls.bgp_routing_instance_1,
             name="Group A",
             role=cls.peeringrole_internal,
             autonomous_system=cls.asn_1,
             description="Internal Group",
+            vrf=vrf_1,
+            source_ip=source_ip_1,
         )
         models.PeerGroup.objects.create(
             routing_instance=cls.bgp_routing_instance_1,
@@ -268,14 +311,17 @@ class PeerGroupTestCase(FilterTestCases.FilterTestCase):
             autonomous_system=cls.asn_1,
             enabled=False,
             description="External Group",
+            vrf=vrf_2,
+            source_ip=source_ip_2
         )
         models.PeerGroup.objects.create(
             routing_instance=cls.bgp_routing_instance_2,
             name="Group C",
             role=cls.peeringrole_internal,
             autonomous_system=asn_2,
-            description="Internal Group",
-            # vrf=cls.vrf
+            description="Hello World",
+            vrf=vrf_3,
+            source_ip=source_ip_3,
         )
         models.PeerGroup.objects.create(
             routing_instance=cls.bgp_routing_instance_3,
@@ -291,7 +337,7 @@ class PeerGroupTestCase(FilterTestCases.FilterTestCase):
         # Match on name (case-insensitive)
         self.assertEqual(self.filterset({"q": "Group A"}, self.queryset).qs.count(), 1)
         self.assertEqual(self.filterset({"q": "group a"}, self.queryset).qs.count(), 1)
-        self.assertEqual(self.filterset({"q": "Internal Group"}, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset({"q": "Internal Group"}, self.queryset).qs.count(), 2)
         self.assertEqual(self.filterset({"q": "External Group"}, self.queryset).qs.count(), 1)
 
     def test_enabled(self):
@@ -308,6 +354,8 @@ class PeerGroupTemplateTestCase(FilterTestCases.FilterTestCase):
 
     generic_filter_tests = (
         ["name"],
+        ["description"],
+        ["role"],
         ["autonomous_system", "autonomous_system__asn"],
     )
 
@@ -331,7 +379,7 @@ class PeerGroupTemplateTestCase(FilterTestCases.FilterTestCase):
         cls.peer_group_template_1 = models.PeerGroupTemplate.objects.create(
             name="Template 1",
             role=role_internal,
-            description="Hello World",
+            description="Group Template 1",
             autonomous_system=asn1,
         )
 
@@ -380,8 +428,11 @@ class PeerEndpointTestCase(FilterTestCases.FilterTestCase):
     filterset = filters.PeerEndpointFilterSet
 
     generic_filter_tests = (
+        ["description"],
+        ["role"],
         ["device", "routing_instance__device__name"],
         ["device", "routing_instance__device__id"],
+        ["device", "routing_instance__device__id"],  #TODO: Remove this when deprecated `device_id` filter id removed
         ["autonomous_system", "autonomous_system__asn"],
         ["peer_group", "peer_group__id"],
         ["peer_group", "peer_group__name"],
@@ -396,8 +447,12 @@ class PeerEndpointTestCase(FilterTestCases.FilterTestCase):
         asn_1 = models.AutonomousSystem.objects.create(asn=4294967295, status=status_active)
         asn_2 = models.AutonomousSystem.objects.create(asn=4294967296, status=status_active)
         asn_3 = models.AutonomousSystem.objects.create(asn=4294967297, status=status_active)
-        peeringrole = Role.objects.create(name="Internal", color="ffffff")
-        peeringrole.content_types.add(ContentType.objects.get_for_model(models.PeerGroup))
+        role_internal = Role.objects.create(name="Internal", color="ffffff")
+        role_internal.content_types.add(ContentType.objects.get_for_model(models.PeerGroup))
+        role_external = Role.objects.create(name="External", color="ffffff")
+        role_external.content_types.add(ContentType.objects.get_for_model(models.PeerEndpoint))
+        role_transit = Role.objects.create(name="Transit", color="ffffff")
+        role_transit.content_types.add(ContentType.objects.get_for_model(models.PeerEndpoint))
         manufacturer = Manufacturer.objects.create(name="Cisco")
         cls.devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="CSR 1000V")
         location_type = LocationType.objects.create(name="site")
@@ -464,17 +519,17 @@ class PeerEndpointTestCase(FilterTestCases.FilterTestCase):
 
         peergroup_1 = models.PeerGroup.objects.create(
             name="Group B",
-            role=peeringrole,
+            role=role_internal,
             routing_instance=bgp_routing_instance_1,
         )
         peergroup_2 = models.PeerGroup.objects.create(
             name="Group C",
-            role=peeringrole,
+            role=role_internal,
             routing_instance=bgp_routing_instance_2,
         )
         peergroup_3 = models.PeerGroup.objects.create(
             name="Group D",
-            role=peeringrole,
+            role=role_internal,
             routing_instance=bgp_routing_instance_3,
         )
 
@@ -482,27 +537,34 @@ class PeerEndpointTestCase(FilterTestCases.FilterTestCase):
         peering2 = models.Peering.objects.create(status=status_active)
         peering3 = models.Peering.objects.create(status=status_active)
 
+
         models.PeerEndpoint.objects.create(
+            description="Peer Endpoint 1",
             routing_instance=bgp_routing_instance_1,
             source_ip=addresses[0],
             autonomous_system=asn_1,
             peer_group=peergroup_1,
             peering=peering1,
+            role=role_internal,
         )
         models.PeerEndpoint.objects.create(
+            description="This is a Peer Endpoint",
             routing_instance=bgp_routing_instance_2,
             source_ip=addresses[1],
             autonomous_system=asn_2,
             peer_group=peergroup_2,
             peering=peering2,
+            role=role_external,
         )
         models.PeerEndpoint.objects.create(
+            description="Hello World",
             routing_instance=bgp_routing_instance_3,
             source_ip=addresses[2],
             autonomous_system=asn_3,
             peer_group=peergroup_3,
             enabled=False,
             peering=peering3,
+            role=role_transit,
         )
 
     def test_search(self):
@@ -817,7 +879,7 @@ class AddressFamilyTestCase(FilterTestCases.FilterTestCase):
         ["afi_safi"],
         ["routing_instance", "routing_instance__id"],
         ["device", "routing_instance__device__name"],
-        ["device", "routing_instance__device__id"],
+        ["device_id", "routing_instance__device__id"],
     )
 
     @classmethod
@@ -906,6 +968,8 @@ class PeerGroupAddressFamilyTestCase(FilterTestCases.FilterTestCase):
 
     generic_filter_tests = (
         ["afi_safi"],
+        ["import_policy"],
+        ["export_policy"],
         ["peer_group", "peer_group__id"],
         ["peer_group", "peer_group__name"],
     )
@@ -970,14 +1034,23 @@ class PeerGroupAddressFamilyTestCase(FilterTestCases.FilterTestCase):
         models.PeerGroupAddressFamily.objects.create(
             peer_group=cls.peergroup_1,
             afi_safi="ipv4_unicast",
+            import_policy="Import Policy 1",
+            export_policy="Export Policy 1",
+            multipath=True,
         )
         models.PeerGroupAddressFamily.objects.create(
             peer_group=peergroup_2,
             afi_safi="ipv6_unicast",
+            import_policy="This is an Import Policy",
+            export_policy="This is an Export Policy",
+            multipath=True,
         )
         models.PeerGroupAddressFamily.objects.create(
             peer_group=peergroup_3,
             afi_safi="ipv4_multicast",
+            import_policy="Hello World",
+            export_policy="Hello World",
+            multipath=False,
         )
 
     def test_search(self):
@@ -986,6 +1059,12 @@ class PeerGroupAddressFamilyTestCase(FilterTestCases.FilterTestCase):
         self.assertEqual(self.filterset({"q": self.peergroup_1.name}, self.queryset).qs.count(), 1)
         self.assertEqual(self.filterset({"q": self.peergroup_1.description}, self.queryset).qs.count(), 1)
 
+    def test_multipath(self):
+        """Test Multipath"""
+        number_of_groups_with_multipath = models.PeerGroupAddressFamily.objects.filter(multipath=True).count()
+        number_of_groups_without_multipath = models.PeerGroupAddressFamily.objects.filter(multipath=False).count()
+        self.assertEqual(self.filterset({"multipath": True}, self.queryset).qs.count(), number_of_groups_with_multipath)
+        self.assertEqual(self.filterset({"multipath": False}, self.queryset).qs.count(), number_of_groups_without_multipath)
 
 class PeerEndpointAddressFamilyTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of PeerEndpointAddressFamily records."""
@@ -996,6 +1075,8 @@ class PeerEndpointAddressFamilyTestCase(FilterTestCases.FilterTestCase):
     generic_filter_tests = (
         ["afi_safi"],
         ["peer_endpoint", "peer_endpoint__id"],
+        ["import_policy"],
+        ["export_policy"],
     )
 
     @classmethod
@@ -1094,14 +1175,23 @@ class PeerEndpointAddressFamilyTestCase(FilterTestCases.FilterTestCase):
         models.PeerEndpointAddressFamily.objects.create(
             peer_endpoint=cls.pe1,
             afi_safi="ipv4_unicast",
+            import_policy="Import Policy 1",
+            export_policy="Export Policy 1",
+            multipath=True,
         )
         models.PeerEndpointAddressFamily.objects.create(
             peer_endpoint=cls.pe1,
             afi_safi="ipv6_unicast",
+            import_policy="This is an Import Policy",
+            export_policy="This is an Export Policy",
+            multipath=True,
         )
         models.PeerEndpointAddressFamily.objects.create(
             peer_endpoint=cls.pe2,
             afi_safi="ipv4_unicast",
+            import_policy="Hello World",
+            export_policy="Hello World",
+            multipath=False,
         )
         models.PeerEndpointAddressFamily.objects.create(
             peer_endpoint=cls.pe3,
@@ -1113,3 +1203,10 @@ class PeerEndpointAddressFamilyTestCase(FilterTestCases.FilterTestCase):
         self.assertEqual(self.filterset({"q": "ipv4_uni"}, self.queryset).qs.count(), 2)
         self.assertEqual(self.filterset({"q": "endpoint"}, self.queryset).qs.count(), 2)
         self.assertEqual(self.filterset({"q": "dev"}, self.queryset).qs.count(), 3)
+
+    def test_multipath(self):
+        """Test Multipath"""
+        number_of_groups_with_multipath = models.PeerEndpointAddressFamily.objects.filter(multipath=True).count()
+        number_of_groups_without_multipath = models.PeerEndpointAddressFamily.objects.filter(multipath=False).count()
+        self.assertEqual(self.filterset({"multipath": True}, self.queryset).qs.count(), number_of_groups_with_multipath)
+        self.assertEqual(self.filterset({"multipath": False}, self.queryset).qs.count(), number_of_groups_without_multipath)

--- a/nautobot_bgp_models/tests/test_filters.py
+++ b/nautobot_bgp_models/tests/test_filters.py
@@ -11,7 +11,6 @@ from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import VRF, IPAddress, Namespace, Prefix
 from nautobot.tenancy.models import Tenant
 
-
 from nautobot_bgp_models import choices, filters, models
 
 
@@ -47,9 +46,9 @@ class AutonomousSystemTestCase(FilterTestCases.FilterTestCase):
         provider_3 = Provider.objects.create(name="Test Provider3")
 
         models.AutonomousSystem.objects.create(
-            asn=4200000000, 
-            status=status_active, 
-            provider=provider_1, 
+            asn=4200000000,
+            status=status_active,
+            provider=provider_1,
             description="Reserved for private use",
         )
         models.AutonomousSystem.objects.create(
@@ -130,7 +129,7 @@ class BGPRoutingInstanceTestCase(FilterTestCases.FilterTestCase):
         ["autonomous_system", "autonomous_system__asn"],
         ["device", "device__name"],
         ["device", "device__id"],
-        ["device_id", "device__id"],  #TODO: Remove this when deprecated `device_id` filter id removed
+        ["device_id", "device__id"],  # TODO: Remove this when deprecated `device_id` filter id removed
         ["status", "status__id"],
         ["status", "status__name"],
     )
@@ -224,11 +223,14 @@ class PeerGroupTestCase(FilterTestCases.FilterTestCase):
         ["routing_instance", "routing_instance__id"],
         ["device", "routing_instance__device__name"],
         ["device", "routing_instance__device__id"],
-        ["device_id", "routing_instance__device__id"],  #TODO: Remove this when deprecated `device_id` filter id removed
+        [
+            "device_id",
+            "routing_instance__device__id",
+        ],  # TODO: Remove this when deprecated `device_id` filter id removed
     )
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # pylint: disable=too-many-locals
         """One-time class setup."""
         status_active = Status.objects.get(name__iexact="active")
         status_active.content_types.add(ContentType.objects.get_for_model(models.AutonomousSystem))
@@ -289,11 +291,9 @@ class PeerGroupTestCase(FilterTestCases.FilterTestCase):
         prefix_status = Status.objects.get_for_model(Prefix).first()
         Prefix.objects.create(prefix="1.0.0.0/8", namespace=namespace, status=prefix_status)
 
-        
         source_ip_1 = IPAddress.objects.create(address="1.1.1.1/32", status=status_active, namespace=namespace)
         source_ip_2 = IPAddress.objects.create(address="1.1.1.2/32", status=status_active, namespace=namespace)
         source_ip_3 = IPAddress.objects.create(address="1.1.1.3/32", status=status_active, namespace=namespace)
-        
 
         models.PeerGroup.objects.create(
             routing_instance=cls.bgp_routing_instance_1,
@@ -312,7 +312,7 @@ class PeerGroupTestCase(FilterTestCases.FilterTestCase):
             enabled=False,
             description="External Group",
             vrf=vrf_2,
-            source_ip=source_ip_2
+            source_ip=source_ip_2,
         )
         models.PeerGroup.objects.create(
             routing_instance=cls.bgp_routing_instance_2,
@@ -432,7 +432,7 @@ class PeerEndpointTestCase(FilterTestCases.FilterTestCase):
         ["role"],
         ["device", "routing_instance__device__name"],
         ["device", "routing_instance__device__id"],
-        ["device", "routing_instance__device__id"],  #TODO: Remove this when deprecated `device_id` filter id removed
+        ["device", "routing_instance__device__id"],  # TODO: Remove this when deprecated `device_id` filter id removed
         ["autonomous_system", "autonomous_system__asn"],
         ["peer_group", "peer_group__id"],
         ["peer_group", "peer_group__name"],
@@ -536,7 +536,6 @@ class PeerEndpointTestCase(FilterTestCases.FilterTestCase):
         peering1 = models.Peering.objects.create(status=status_active)
         peering2 = models.Peering.objects.create(status=status_active)
         peering3 = models.Peering.objects.create(status=status_active)
-
 
         models.PeerEndpoint.objects.create(
             description="Peer Endpoint 1",
@@ -1064,7 +1063,10 @@ class PeerGroupAddressFamilyTestCase(FilterTestCases.FilterTestCase):
         number_of_groups_with_multipath = models.PeerGroupAddressFamily.objects.filter(multipath=True).count()
         number_of_groups_without_multipath = models.PeerGroupAddressFamily.objects.filter(multipath=False).count()
         self.assertEqual(self.filterset({"multipath": True}, self.queryset).qs.count(), number_of_groups_with_multipath)
-        self.assertEqual(self.filterset({"multipath": False}, self.queryset).qs.count(), number_of_groups_without_multipath)
+        self.assertEqual(
+            self.filterset({"multipath": False}, self.queryset).qs.count(), number_of_groups_without_multipath
+        )
+
 
 class PeerEndpointAddressFamilyTestCase(FilterTestCases.FilterTestCase):
     """Test filtering of PeerEndpointAddressFamily records."""
@@ -1209,4 +1211,6 @@ class PeerEndpointAddressFamilyTestCase(FilterTestCases.FilterTestCase):
         number_of_groups_with_multipath = models.PeerEndpointAddressFamily.objects.filter(multipath=True).count()
         number_of_groups_without_multipath = models.PeerEndpointAddressFamily.objects.filter(multipath=False).count()
         self.assertEqual(self.filterset({"multipath": True}, self.queryset).qs.count(), number_of_groups_with_multipath)
-        self.assertEqual(self.filterset({"multipath": False}, self.queryset).qs.count(), number_of_groups_without_multipath)
+        self.assertEqual(
+            self.filterset({"multipath": False}, self.queryset).qs.count(), number_of_groups_without_multipath
+        )

--- a/nautobot_bgp_models/tests/test_filters.py
+++ b/nautobot_bgp_models/tests/test_filters.py
@@ -432,7 +432,10 @@ class PeerEndpointTestCase(FilterTestCases.FilterTestCase):
         ["role"],
         ["device", "routing_instance__device__name"],
         ["device", "routing_instance__device__id"],
-        ["device", "routing_instance__device__id"],  # TODO: Remove this when deprecated `device_id` filter id removed
+        [
+            "device_id",
+            "routing_instance__device__id",
+        ],  # TODO: Remove this when deprecated `device_id` filter id removed
         ["autonomous_system", "autonomous_system__asn"],
         ["peer_group", "peer_group__id"],
         ["peer_group", "peer_group__name"],
@@ -587,6 +590,10 @@ class PeeringTestCase(FilterTestCases.FilterTestCase):
         ["status", "status__name"],
         ["device", "endpoints__routing_instance__device__name"],
         ["device", "endpoints__routing_instance__device__id"],
+        [
+            "device_id",
+            "endpoints__routing_instance__device__id",
+        ],  # TODO: Remove this when deprecated `device_id` filter id removed
         ["device_role", "endpoints__routing_instance__device__role__name"],
         ["peer_endpoint_role", "endpoints__role__name"],
     )
@@ -877,8 +884,6 @@ class AddressFamilyTestCase(FilterTestCases.FilterTestCase):
         ["vrf"],
         ["afi_safi"],
         ["routing_instance", "routing_instance__id"],
-        ["device", "routing_instance__device__name"],
-        ["device_id", "routing_instance__device__id"],
     )
 
     @classmethod


### PR DESCRIPTION
# Closes: #NAPPS-691

## What's Changed
- Replaced `BaseFilterTestCase` with `FilterTestCase`.
- Added `generic_filter_tests` to tests and removed test cases that it replaces.
- Added test data so tests would have enough for `generic_filter_tests`.
- Added missing test cases for `BGPRoutingInstanceTestCase` and `PeerGroupTemplateTestCase`.
- Changed device filter to use `NaturalKeyOrPKMultipleChoiceFilter`.
- Added filter support to models that were lacking it.
- Replaced filtersets using `BaseFilterSet, CreatedUpdatedModelFilterSetMixin, CustomFieldModelFilterSetMixin,` with `NautobotFilterSet`.


## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests
