### PR TITLE
[LTM 2.4 Backport] Fixed the ability to select Interfaces and IPs on modules for a BGP Peering or Peer Group

### DIFF
--- a/changes/304.fixed
+++ b/changes/304.fixed
@@ -1,0 +1,2 @@
+Fixed an issue where Interfaces on a module were not being presented to apply to a BGP Peering or Peer Groups.
+Fixed an issue where IP Addresses assigned to interfaces on a module were not being presented to apply to a BGP Peering or Peer Groups.

--- a/nautobot_bgp_models/filter_extensions.py
+++ b/nautobot_bgp_models/filter_extensions.py
@@ -1,7 +1,47 @@
 """Filter Extensions definitions for nautobot_bgp_models."""
 
 from django import forms
+from django.db.models import Q
 from nautobot.apps.filters import FilterExtension, MultiValueCharFilter
+from nautobot.dcim.constants import MODULE_RECURSION_DEPTH_LIMIT
+
+
+def _q_routing_instance_ids_via_parent_device(value, prefix=""):
+    """
+    Build a Q that matches when the interface's parent device has any of the given routing instance IDs.
+
+    Mirrors Interface.parent (device or module chain to device). Prefix is "" for Interface
+    queryset, "interfaces__" for IPAddress queryset.
+    """
+    if not value:
+        return Q(pk__in=[])
+    if isinstance(value, str):
+        value = [value]
+    value = [str(v).strip() for v in value if v is not None and str(v).strip()]
+
+    suffix = "bgp_routing_instances__id__in"
+    query = Q(**{f"{prefix}device__{suffix}": value})
+    recursion_depth = MODULE_RECURSION_DEPTH_LIMIT - 1
+    for level in range(recursion_depth):
+        recursive_part = "module__parent_module_bay__" + "parent_module__parent_module_bay__" * level
+        query = query | Q(**{f"{prefix}{recursive_part}parent_device__{suffix}": value})
+    return query
+
+
+def _filter_ips_by_routing_instance(queryset, name, value):  # pylint: disable=unused-argument
+    """Filter IPAddress queryset by routing instance UUID(s) via interface's parent device."""
+    if not value:
+        return queryset
+    q = _q_routing_instance_ids_via_parent_device(value, "interfaces__")
+    return queryset.filter(q).distinct()
+
+
+def _filter_interfaces_by_routing_instance(queryset, name, value):  # pylint: disable=unused-argument
+    """Filter Interface queryset by routing instance UUID(s) via parent device (device or module chain)."""
+    if not value:
+        return queryset
+    q = _q_routing_instance_ids_via_parent_device(value)
+    return queryset.filter(q)
 
 
 class IPAddressFilterExtension(FilterExtension):
@@ -11,7 +51,7 @@ class IPAddressFilterExtension(FilterExtension):
 
     filterset_fields = {
         "nautobot_bgp_models_ips_bgp_routing_instance": MultiValueCharFilter(
-            field_name="interfaces__device__bgp_routing_instances__id",
+            method=_filter_ips_by_routing_instance,
             label="Routing Instance UUID",
         ),
     }
@@ -28,7 +68,7 @@ class InterfaceFilterExtension(FilterExtension):
 
     filterset_fields = {
         "nautobot_bgp_models_interfaces_bgp_routing_instance": MultiValueCharFilter(
-            field_name="device__bgp_routing_instances__id",
+            method=_filter_interfaces_by_routing_instance,
             label="Routing Instance UUID",
         ),
     }

--- a/nautobot_bgp_models/tests/test_filters.py
+++ b/nautobot_bgp_models/tests/test_filters.py
@@ -1,15 +1,34 @@
 """Unit test automation for FilterSet classes in nautobot_bgp_models."""
 
 from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
 
 # from nautobot.circuits.models import Provider
 from nautobot.apps.testing import FilterTestCases
+from nautobot.core.utils.lookup import get_filterset_for_model
 from nautobot.dcim.choices import InterfaceTypeChoices
-from nautobot.dcim.models import Device, DeviceType, Interface, Location, LocationType, Manufacturer
+from nautobot.dcim.models import (
+    Device,
+    DeviceType,
+    Interface,
+    InterfaceTemplate,
+    Location,
+    LocationType,
+    Manufacturer,
+    Module,
+    ModuleBay,
+    ModuleBayTemplate,
+    ModuleType,
+)
 from nautobot.extras.models import Role, Status
 from nautobot.ipam.models import VRF, IPAddress, Namespace, Prefix
 
 from nautobot_bgp_models import choices, filters, models
+from nautobot_bgp_models.filter_extensions import (
+    _filter_interfaces_by_routing_instance,
+    _filter_ips_by_routing_instance,
+    _q_routing_instance_ids_via_parent_device,
+)
 
 
 class AutonomousSystemTestCase(FilterTestCases.BaseFilterTestCase):
@@ -1004,3 +1023,223 @@ class PeerEndpointAddressFamilyTestCase(FilterTestCases.BaseFilterTestCase):
     def test_peer_endpoint(self):
         """Test filtering by peer_endpoint."""
         self.assertEqual(self.filterset({"peer_endpoint": [self.pe1.pk, self.pe2.pk]}, self.queryset).qs.count(), 3)
+
+
+class FilterExtensionTestCase(TestCase):
+    """Test filter extensions."""
+
+    @classmethod
+    def setUpTestData(cls):  # pylint: disable=too-many-locals
+        """Create device with direct interface and device with module + interface on module; BGP instance on device."""
+        status_active = Status.objects.get(name__iexact="active")
+
+        manufacturer = Manufacturer.objects.create(name="Cisco-Test")
+        devicetype = DeviceType.objects.create(manufacturer=manufacturer, model="CSR 1000V")
+        InterfaceTemplate.objects.create(
+            device_type=devicetype, name="Loopback0", type=InterfaceTypeChoices.TYPE_VIRTUAL
+        )
+        ModuleBayTemplate.objects.create(device_type=devicetype, name="Slot1", position="1")
+
+        location_type = LocationType.objects.create(name="Site")
+        location = Location.objects.create(name="Site 1", location_type=location_type, status=status_active)
+        devicerole = Role.objects.create(name="Router", color="ff0000")
+        devicerole.content_types.add(ContentType.objects.get_for_model(Device))
+
+        cls.device = Device.objects.create(
+            device_type=devicetype,
+            role=devicerole,
+            name="Device-With-Module",
+            location=location,
+            status=status_active,
+        )
+        module_bay = ModuleBay.objects.get(parent_device=cls.device, name="Slot1")
+
+        module_type = ModuleType.objects.create(manufacturer=manufacturer, model="Linecard")
+        InterfaceTemplate.objects.create(
+            module_type=module_type,
+            name="Ethernet0",
+            type=InterfaceTypeChoices.TYPE_OTHER,
+        )
+        cls.module = Module.objects.create(module_type=module_type, parent_module_bay=module_bay, status=status_active)
+
+        cls.interface_on_device = Interface.objects.get(device=cls.device, name="Loopback0")
+        cls.interface_on_module = Interface.objects.get(module=cls.module, name="Ethernet0")
+
+        cls.bgp_routing_instance = models.BGPRoutingInstance.objects.create(
+            device=cls.device,
+            autonomous_system=models.AutonomousSystem.objects.create(asn=65001, status=status_active),
+            status=status_active,
+        )
+
+        namespace = Namespace.objects.first()
+        if not Prefix.objects.filter(namespace=namespace, prefix="10.0.0.0/8").exists():
+            Prefix.objects.create(prefix="10.0.0.0/8", namespace=namespace, status=status_active)
+        cls.ip_on_device_interface = IPAddress.objects.create(
+            address="10.1.1.1/32", status=status_active, namespace=namespace
+        )
+        cls.ip_on_module_interface = IPAddress.objects.create(
+            address="10.1.1.2/32", status=status_active, namespace=namespace
+        )
+        cls.interface_on_device.add_ip_addresses([cls.ip_on_device_interface])
+        cls.interface_on_module.add_ip_addresses([cls.ip_on_module_interface])
+
+        # Another device with no BGP instance (to ensure filter excludes its IP/interface)
+        device_other = Device.objects.create(
+            device_type=devicetype,
+            role=devicerole,
+            name="Device-Other",
+            location=location,
+            status=status_active,
+        )
+        if_other = Interface.objects.get(device=device_other, name="Loopback0")
+        cls.ip_other = IPAddress.objects.create(address="10.2.2.2/32", status=status_active, namespace=namespace)
+        if_other.add_ip_addresses([cls.ip_other])
+
+    def test_ip_address_filter_by_routing_instance_includes_direct_and_module_interfaces(self):
+        """Filtering IPAddress by routing instance UUID returns IPs on device and on module interfaces."""
+        filterset_class = get_filterset_for_model("ipam.ipaddress")
+        self.assertIsNotNone(filterset_class)
+        self.assertIn("nautobot_bgp_models_ips_bgp_routing_instance", filterset_class().filters)
+
+        queryset = IPAddress.objects.all()
+        params = {"nautobot_bgp_models_ips_bgp_routing_instance": [str(self.bgp_routing_instance.pk)]}
+        filtered = filterset_class(params, queryset).qs
+
+        self.assertIn(self.ip_on_device_interface, filtered)
+        self.assertIn(self.ip_on_module_interface, filtered)
+        self.assertNotIn(self.ip_other, filtered)
+        self.assertEqual(filtered.count(), 2)
+
+    def test_interface_filter_by_routing_instance_includes_direct_and_module_interfaces(self):
+        """Filtering Interface by routing instance UUID returns interfaces on device and on module."""
+        filterset_class = get_filterset_for_model("dcim.interface")
+        self.assertIsNotNone(filterset_class)
+        self.assertIn("nautobot_bgp_models_interfaces_bgp_routing_instance", filterset_class().filters)
+
+        queryset = Interface.objects.all()
+        params = {"nautobot_bgp_models_interfaces_bgp_routing_instance": [str(self.bgp_routing_instance.pk)]}
+        filtered = filterset_class(params, queryset).qs
+
+        self.assertIn(self.interface_on_device, filtered)
+        self.assertIn(self.interface_on_module, filtered)
+        self.assertEqual(filtered.count(), 2)
+
+    def test_ip_address_filter_with_empty_value_returns_all(self):
+        """Filtering IPAddress with empty value returns unfiltered queryset."""
+        filterset_class = get_filterset_for_model("ipam.ipaddress")
+        queryset = IPAddress.objects.all()
+        original_count = queryset.count()
+
+        # Test with empty list
+        params = {"nautobot_bgp_models_ips_bgp_routing_instance": []}
+        filtered = filterset_class(params, queryset).qs
+        self.assertEqual(filtered.count(), original_count)
+
+        # Test with None (simulated by not providing the param)
+        filtered = filterset_class({}, queryset).qs
+        self.assertEqual(filtered.count(), original_count)
+
+    def test_interface_filter_with_empty_value_returns_all(self):
+        """Filtering Interface with empty value returns unfiltered queryset."""
+        filterset_class = get_filterset_for_model("dcim.interface")
+        queryset = Interface.objects.all()
+        original_count = queryset.count()
+
+        # Test with empty list
+        params = {"nautobot_bgp_models_interfaces_bgp_routing_instance": []}
+        filtered = filterset_class(params, queryset).qs
+        self.assertEqual(filtered.count(), original_count)
+
+        # Test with None (simulated by not providing the param)
+        filtered = filterset_class({}, queryset).qs
+        self.assertEqual(filtered.count(), original_count)
+
+    def test_ip_address_filter_with_string_value(self):
+        """Filtering IPAddress with string value (instead of list) works correctly."""
+        filterset_class = get_filterset_for_model("ipam.ipaddress")
+        queryset = IPAddress.objects.all()
+
+        # Test with string value (should be converted to list internally)
+        params = {"nautobot_bgp_models_ips_bgp_routing_instance": str(self.bgp_routing_instance.pk)}
+        filtered = filterset_class(params, queryset).qs
+
+        self.assertIn(self.ip_on_device_interface, filtered)
+        self.assertIn(self.ip_on_module_interface, filtered)
+        self.assertNotIn(self.ip_other, filtered)
+        self.assertEqual(filtered.count(), 2)
+
+    def test_interface_filter_with_string_value(self):
+        """Filtering Interface with string value (instead of list) works correctly."""
+        filterset_class = get_filterset_for_model("dcim.interface")
+        queryset = Interface.objects.all()
+
+        # Test with string value (should be converted to list internally)
+        params = {"nautobot_bgp_models_interfaces_bgp_routing_instance": str(self.bgp_routing_instance.pk)}
+        filtered = filterset_class(params, queryset).qs
+
+        self.assertIn(self.interface_on_device, filtered)
+        self.assertIn(self.interface_on_module, filtered)
+        self.assertEqual(filtered.count(), 2)
+
+    def test_ip_address_filter_with_whitespace_only_values(self):
+        """Filtering IPAddress with whitespace-only values returns no results."""
+        filterset_class = get_filterset_for_model("ipam.ipaddress")
+        queryset = IPAddress.objects.all()
+
+        # Test with list containing only whitespace/empty strings (gets filtered out, resulting in empty list)
+        # This tests the edge case where value becomes empty after processing
+        params = {"nautobot_bgp_models_ips_bgp_routing_instance": ["", "   ", "\t"]}
+        filtered = filterset_class(params, queryset).qs
+        # After filtering out empty strings, the helper receives an empty list
+        # This should result in no matches
+        self.assertEqual(filtered.count(), 0)
+
+        # Test the helper directly with empty list
+        q = _q_routing_instance_ids_via_parent_device([], "interfaces__")
+        filtered_direct = queryset.filter(q)
+        self.assertEqual(filtered_direct.count(), 0)
+
+        # Test the helper directly with string value
+        q = _q_routing_instance_ids_via_parent_device(str(self.bgp_routing_instance.pk), "interfaces__")
+        filtered_string = queryset.filter(q).distinct()
+        self.assertIn(self.ip_on_device_interface, filtered_string)
+        self.assertIn(self.ip_on_module_interface, filtered_string)
+
+        # Test filter function directly with empty value
+        result = _filter_ips_by_routing_instance(queryset, "test", [])
+        self.assertEqual(result.count(), queryset.count())
+        result = _filter_ips_by_routing_instance(queryset, "test", None)
+        self.assertEqual(result.count(), queryset.count())
+        result = _filter_ips_by_routing_instance(queryset, "test", "")
+        self.assertEqual(result.count(), queryset.count())
+
+    def test_interface_filter_with_whitespace_only_values(self):
+        """Filtering Interface with whitespace-only values returns no results."""
+        filterset_class = get_filterset_for_model("dcim.interface")
+        queryset = Interface.objects.all()
+
+        # Test with list containing only whitespace/empty strings (gets filtered out, resulting in empty list)
+        params = {"nautobot_bgp_models_interfaces_bgp_routing_instance": ["", "   ", "\t"]}
+        filtered = filterset_class(params, queryset).qs
+        # After filtering out empty strings, the helper receives an empty list
+        # This should result in no matches
+        self.assertEqual(filtered.count(), 0)
+
+        # Test the helper directly with empty list
+        q = _q_routing_instance_ids_via_parent_device([], "")
+        filtered_direct = queryset.filter(q)
+        self.assertEqual(filtered_direct.count(), 0)
+
+        # Test the helper directly with string value
+        q = _q_routing_instance_ids_via_parent_device(str(self.bgp_routing_instance.pk), "")
+        filtered_string = queryset.filter(q)
+        self.assertIn(self.interface_on_device, filtered_string)
+        self.assertIn(self.interface_on_module, filtered_string)
+
+        # Test filter function directly with empty value
+        result = _filter_interfaces_by_routing_instance(queryset, "test", [])
+        self.assertEqual(result.count(), queryset.count())
+        result = _filter_interfaces_by_routing_instance(queryset, "test", None)
+        self.assertEqual(result.count(), queryset.count())
+        result = _filter_interfaces_by_routing_instance(queryset, "test", "")
+        self.assertEqual(result.count(), queryset.count())


### PR DESCRIPTION
This is a copy/paste backport of #306 for the ltm-2.4 branch.