### PR TITLE
Release v2.4.1

### DIFF
--- a/changes/296.added
+++ b/changes/296.added
@@ -1,1 +1,0 @@
-Updated PeerEndpoint VRF validation to include related interface as a source for VRF configuration.

--- a/changes/304.fixed
+++ b/changes/304.fixed
@@ -1,2 +1,0 @@
-Fixed an issue where Interfaces on a module were not being presented to apply to a BGP Peering or Peer Groups.
-Fixed an issue where IP Addresses assigned to interfaces on a module were not being presented to apply to a BGP Peering or Peer Groups.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -8,6 +8,19 @@ This document describes all new features and changes in the release. The format 
 - Dropped support for Python 3.9.
 
 <!-- towncrier release notes start -->
+
+
+## [v2.4.1 (2026-02-18)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v2.4.1)
+
+### Added
+
+- [#296](https://github.com/nautobot/nautobot-app-bgp-models/issues/296) - Updated PeerEndpoint VRF validation to include related interface as a source for VRF configuration.
+
+### Fixed
+
+- [#304](https://github.com/nautobot/nautobot-app-bgp-models/issues/304) - Fixed an issue where Interfaces on a module were not being presented to apply to a BGP Peering or Peer Groups.
+- [#304](https://github.com/nautobot/nautobot-app-bgp-models/issues/304) - Fixed an issue where IP Addresses assigned to interfaces on a module were not being presented to apply to a BGP Peering or Peer Groups.
+
 ## [v2.4.0 (2025-12-12)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v2.4.0)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-bgp-models"
-version = "2.4.0"
+version = "2.4.1"
 description = "Nautobot BGP Models App"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v2.4.1 (2026-02-18)](https://github.com/nautobot/nautobot-app-bgp-models/releases/tag/v2.4.1)

### Added

- [#296](https://github.com/nautobot/nautobot-app-bgp-models/issues/296) - Updated PeerEndpoint VRF validation to include related interface as a source for VRF configuration.

### Fixed

- [#304](https://github.com/nautobot/nautobot-app-bgp-models/issues/304) - Fixed an issue where Interfaces on a module were not being presented to apply to a BGP Peering or Peer Groups.
- [#304](https://github.com/nautobot/nautobot-app-bgp-models/issues/304) - Fixed an issue where IP Addresses assigned to interfaces on a module were not being presented to apply to a BGP Peering or Peer Groups.