### PR TITLE
Change on_delete behavior for source_interface field

### DIFF
--- a/nautobot_bgp_models/models.py
+++ b/nautobot_bgp_models/models.py
@@ -366,7 +366,7 @@ class PeerGroup(PrimaryModel, InheritanceMixin, BGPExtraAttributesMixin):
 
     source_interface = models.ForeignKey(  # update source Interface
         to="dcim.Interface",
-        on_delete=models.PROTECT,
+        on_delete=models.CASCADE,
         blank=True,
         null=True,
         related_name="bgp_peer_groups",


### PR DESCRIPTION
If the interface is deleted, then the peer group doesn't need to exist. This currently blocks the deletion of the entire device.

## What's Changed

Peer groups are now deleted when their source interface is deleted, instead of blocking the deletion.

## To Do
None
